### PR TITLE
replace the deprecated tempdir crate with tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ features = ["derive"]
 
 [dev-dependencies]
 byteorder = "1"
-tempdir = "0.3"
+tempfile = "3"

--- a/src/env.rs
+++ b/src/env.rs
@@ -142,7 +142,7 @@ impl Rkv {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
     extern crate byteorder;
 
     use self::byteorder::{
@@ -150,8 +150,8 @@ mod tests {
         LittleEndian,
     };
 
-    use self::tempdir::{
-        TempDir,
+    use self::tempfile::{
+        Builder,
     };
 
     use std::{
@@ -165,7 +165,7 @@ mod tests {
     /// We can't open a directory that doesn't exist.
     #[test]
     fn test_open_fails() {
-        let root = TempDir::new("test_open_fails").expect("tempdir");
+        let root = Builder::new().prefix("test_open_fails").tempdir().expect("tempdir");
         assert!(root.path().exists());
 
         let nope = root.path().join("nope/");
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_open() {
-        let root = TempDir::new("test_open").expect("tempdir");
+        let root = Builder::new().prefix("test_open").tempdir().expect("tempdir");
         println!("Root path: {:?}", root.path());
         fs::create_dir_all(root.path()).expect("dir created");
         assert!(root.path().is_dir());
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn test_round_trip_and_transactions() {
-        let root = TempDir::new("test_round_trip_and_transactions").expect("tempdir");
+        let root = Builder::new().prefix("test_round_trip_and_transactions").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
 
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn test_read_before_write_num() {
-        let root = TempDir::new("test_read_before_write_num").expect("tempdir");
+        let root = Builder::new().prefix("test_read_before_write_num").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let sk: Store<&str> = k.create_or_open("sk").expect("opened");
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_read_before_write_str() {
-        let root = TempDir::new("test_read_before_write_str").expect("tempdir");
+        let root = Builder::new().prefix("test_read_before_write_str").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let sk: Store<&str> = k.create_or_open("sk").expect("opened");
@@ -351,7 +351,7 @@ mod tests {
 
     #[test]
     fn test_concurrent_read_transactions_prohibited() {
-        let root = TempDir::new("test_concurrent_reads_prohibited").expect("tempdir");
+        let root = Builder::new().prefix("test_concurrent_reads_prohibited").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let s: Store<&str> = k.create_or_open("s").expect("opened");
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn test_isolation() {
-        let root = TempDir::new("test_isolation").expect("tempdir");
+        let root = Builder::new().prefix("test_isolation").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let s: Store<&str> = k.create_or_open("s").expect("opened");
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_blob() {
-        let root = TempDir::new("test_round_trip_blob").expect("tempdir");
+        let root = Builder::new().prefix("test_round_trip_blob").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let sk: Store<&str> = k.create_or_open("sk").expect("opened");
@@ -456,7 +456,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "not yet implemented")]
     fn test_delete_value() {
-        let root = TempDir::new("test_delete_value").expect("tempdir");
+        let root = Builder::new().prefix("test_delete_value").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let sk: Store<&str> = k.create_or_open_with_flags("sk", lmdb::DUP_SORT).expect("opened");
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_iter() {
-        let root = TempDir::new("test_iter").expect("tempdir");
+        let root = Builder::new().prefix("test_iter").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let sk: Store<&str> = k.create_or_open("sk").expect("opened");
@@ -544,7 +544,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: NotFound")]
     fn test_iter_from_key_greater_than_existing() {
-        let root = TempDir::new("test_iter_from_key_greater_than_existing").expect("tempdir");
+        let root = Builder::new().prefix("test_iter_from_key_greater_than_existing").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let sk: Store<&str> = k.create_or_open("sk").expect("opened");

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -142,16 +142,18 @@ impl<K> IntegerStore<K> where K: PrimitiveInt {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::{
+        Builder,
+    };
     use std::fs;
 
     use super::*;
 
     #[test]
     fn test_integer_keys() {
-        let root = TempDir::new("test_integer_keys").expect("tempdir");
+        let root = Builder::new().prefix("test_integer_keys").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let mut s: IntegerStore<u32> = k.create_or_open_integer("s").expect("open");

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -98,9 +98,11 @@ impl Manager {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempdir;
+    extern crate tempfile;
 
-    use self::tempdir::TempDir;
+    use self::tempfile::{
+        Builder,
+    };
     use std::fs;
 
     use super::*;
@@ -108,7 +110,7 @@ mod tests {
     /// Test that the manager will return the same Rkv instance each time for each path.
     #[test]
     fn test_same() {
-        let root = TempDir::new("test_same").expect("tempdir");
+        let root = Builder::new().prefix("test_same").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
 
         let mut manager = Manager::new();
@@ -124,7 +126,7 @@ mod tests {
     /// Test that the manager will return the same Rkv instance each time for each path.
     #[test]
     fn test_same_with_capacity() {
-        let root = TempDir::new("test_same").expect("tempdir");
+        let root = Builder::new().prefix("test_same").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
 
         let mut manager = Manager::new();

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -9,14 +9,16 @@
 // specific language governing permissions and limitations under the License.
 
 extern crate rkv;
-extern crate tempdir;
+extern crate tempfile;
 
 use rkv::{
 	Manager,
 	Rkv,
 };
 
-use self::tempdir::TempDir;
+use self::tempfile::{
+    Builder,
+};
 
 use std::fs;
 
@@ -28,7 +30,7 @@ use std::sync::{
 // Identical to the same-named unit test, but this one confirms that it works
 // via the public MANAGER singleton.
 fn test_same() {
-    let root = TempDir::new("test_same_singleton").expect("tempdir");
+    let root = Builder::new().prefix("test_same_singleton").tempdir().expect("tempdir");
     fs::create_dir_all(root.path()).expect("dir created");
 
     let p = root.path();


### PR DESCRIPTION
Per [this note](https://github.com/rust-lang-nursery/tempdir#deprecation-note), tempdir has been merged into [tempfile](https://github.com/Stebalien/tempfile). Fixing it as my good-first-bug to rkv ;)

r? @mykmelez 