### PR TITLE
add rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+imports_layout = "Vertical"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,16 +8,12 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use std::path::{
-    PathBuf,
-};
+use std::path::PathBuf;
 
 use bincode;
 use lmdb;
 
-use value::{
-    Type,
-};
+use value::Type;
 
 #[derive(Debug, Fail)]
 pub enum DataError {
@@ -25,10 +21,7 @@ pub enum DataError {
     UnknownType(u8),
 
     #[fail(display = "unexpected type tag: expected {}, got {}", expected, actual)]
-    UnexpectedType {
-        expected: Type,
-        actual: Type,
-    },
+    UnexpectedType { expected: Type, actual: Type },
 
     #[fail(display = "empty data; expected tag")]
     Empty,
@@ -82,7 +75,9 @@ impl StoreError {
 impl From<lmdb::Error> for StoreError {
     fn from(e: lmdb::Error) -> StoreError {
         match e {
-            lmdb::Error::BadRslot => StoreError::ReadTransactionAlreadyExists(::std::thread::current().id()),
+            lmdb::Error::BadRslot => {
+                StoreError::ReadTransactionAlreadyExists(::std::thread::current().id())
+            }
             e @ _ => StoreError::LmdbError(e),
         }
     }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -8,13 +8,11 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use std::marker::{
-    PhantomData,
-};
+use std::marker::PhantomData;
 
 use bincode::{
-    Infinite,
     serialize,
+    Infinite,
 };
 
 use lmdb::{
@@ -22,18 +20,14 @@ use lmdb::{
     RoTransaction,
 };
 
-use serde::{
-    Serialize,
-};
+use serde::Serialize;
 
 use error::{
     DataError,
     StoreError,
 };
 
-use value::{
-    Value,
-};
+use value::Value;
 
 use readwrite::{
     Reader,
@@ -41,8 +35,7 @@ use readwrite::{
     Writer,
 };
 
-use ::Rkv;
-
+use Rkv;
 
 pub trait EncodableKey {
     fn to_bytes(&self) -> Result<Vec<u8>, DataError>;
@@ -52,7 +45,10 @@ pub trait PrimitiveInt: EncodableKey {}
 
 impl PrimitiveInt for u32 {}
 
-impl<T> EncodableKey for T where T: Serialize {
+impl<T> EncodableKey for T
+where
+    T: Serialize,
+{
     fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
         serialize(self, Infinite)         // TODO: limited key length.
         .map_err(|e| e.into())
@@ -64,13 +60,19 @@ struct Key<K> {
     phantom: PhantomData<K>,
 }
 
-impl<K> AsRef<[u8]> for Key<K> where K: EncodableKey {
+impl<K> AsRef<[u8]> for Key<K>
+where
+    K: EncodableKey,
+{
     fn as_ref(&self) -> &[u8] {
         self.bytes.as_ref()
     }
 }
 
-impl<K> Key<K> where K: EncodableKey {
+impl<K> Key<K>
+where
+    K: EncodableKey,
+{
     fn new(k: K) -> Result<Key<K>, DataError> {
         Ok(Key {
             bytes: k.to_bytes()?,
@@ -79,15 +81,24 @@ impl<K> Key<K> where K: EncodableKey {
     }
 }
 
-pub struct IntegerStore<K> where K: PrimitiveInt {
+pub struct IntegerStore<K>
+where
+    K: PrimitiveInt,
+{
     inner: Store<Key<K>>,
 }
 
-pub struct IntegerReader<'env, K> where K: PrimitiveInt {
+pub struct IntegerReader<'env, K>
+where
+    K: PrimitiveInt,
+{
     inner: Reader<'env, Key<K>>,
 }
 
-impl<'env, K> IntegerReader<'env, K> where K: PrimitiveInt {
+impl<'env, K> IntegerReader<'env, K>
+where
+    K: PrimitiveInt,
+{
     pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
         self.inner.get(Key::new(k)?)
     }
@@ -97,11 +108,17 @@ impl<'env, K> IntegerReader<'env, K> where K: PrimitiveInt {
     }
 }
 
-pub struct IntegerWriter<'env, K> where K: PrimitiveInt {
+pub struct IntegerWriter<'env, K>
+where
+    K: PrimitiveInt,
+{
     inner: Writer<'env, Key<K>>,
 }
 
-impl<'env, K> IntegerWriter<'env, K> where K: PrimitiveInt {
+impl<'env, K> IntegerWriter<'env, K>
+where
+    K: PrimitiveInt,
+{
     pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
         self.inner.get(Key::new(k)?)
     }
@@ -115,7 +132,10 @@ impl<'env, K> IntegerWriter<'env, K> where K: PrimitiveInt {
     }
 }
 
-impl<K> IntegerStore<K> where K: PrimitiveInt {
+impl<K> IntegerStore<K>
+where
+    K: PrimitiveInt,
+{
     pub fn new(db: Database) -> IntegerStore<K> {
         IntegerStore {
             inner: Store::new(db),
@@ -134,7 +154,11 @@ impl<K> IntegerStore<K> where K: PrimitiveInt {
         })
     }
 
-    pub fn get<'env, 'tx>(&self, tx: &'tx RoTransaction<'env>, k: K) -> Result<Option<Value<'tx>>, StoreError> {
+    pub fn get<'env, 'tx>(
+        &self,
+        tx: &'tx RoTransaction<'env>,
+        k: K,
+    ) -> Result<Option<Value<'tx>>, StoreError> {
         let key = Key::new(k)?;
         self.inner.get(tx, key)
     }
@@ -144,16 +168,17 @@ impl<K> IntegerStore<K> where K: PrimitiveInt {
 mod tests {
     extern crate tempfile;
 
-    use self::tempfile::{
-        Builder,
-    };
+    use self::tempfile::Builder;
     use std::fs;
 
     use super::*;
 
     #[test]
     fn test_integer_keys() {
-        let root = Builder::new().prefix("test_integer_keys").tempdir().expect("tempdir");
+        let root = Builder::new()
+            .prefix("test_integer_keys")
+            .tempdir()
+            .expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         let mut s: IntegerStore<u32> = k.create_or_open_integer("s").expect("open");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,17 @@
 
 #![allow(dead_code)]
 
-#[macro_use] extern crate arrayref;
-#[macro_use] extern crate failure;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate arrayref;
+#[macro_use]
+extern crate failure;
+#[macro_use]
+extern crate lazy_static;
 
 extern crate bincode;
 extern crate lmdb;
 extern crate ordered_float;
-extern crate serde;               // So we can specify trait bounds. Everything else is bincode.
+extern crate serde; // So we can specify trait bounds. Everything else is bincode.
 extern crate uuid;
 
 pub use lmdb::{
@@ -27,16 +30,14 @@ pub use lmdb::{
     WriteFlags,
 };
 
-pub mod value;
-pub mod error;
 mod env;
-mod readwrite;
+pub mod error;
 mod integer;
 mod manager;
+mod readwrite;
+pub mod value;
 
-pub use env::{
-    Rkv,
-};
+pub use env::Rkv;
 
 pub use error::{
     DataError,
@@ -48,16 +49,12 @@ pub use integer::{
     PrimitiveInt,
 };
 
-pub use manager::{
-    Manager
-};
+pub use manager::Manager;
 
 pub use readwrite::{
     Reader,
-    Writer,
     Store,
+    Writer,
 };
 
-pub use value::{
-    Value,
-};
+pub use value::Value;

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -10,9 +10,7 @@
 
 use lmdb;
 
-use std::marker::{
-    PhantomData,
-};
+use std::marker::PhantomData;
 
 use lmdb::{
     Cursor,
@@ -24,36 +22,37 @@ use lmdb::{
     Transaction,
 };
 
-use lmdb::{
-    WriteFlags,
-};
+use lmdb::WriteFlags;
 
-use error::{
-    StoreError,
-};
+use error::StoreError;
 
-use value::{
-    Value,
-};
+use value::Value;
 
-use ::Rkv;
+use Rkv;
 
 fn read_transform<'x>(val: Result<&'x [u8], lmdb::Error>) -> Result<Option<Value<'x>>, StoreError> {
     match val {
-        Ok(bytes) => Value::from_tagged_slice(bytes).map(Some)
-                                                    .map_err(StoreError::DataError),
+        Ok(bytes) => Value::from_tagged_slice(bytes)
+            .map(Some)
+            .map_err(StoreError::DataError),
         Err(lmdb::Error::NotFound) => Ok(None),
         Err(e) => Err(StoreError::LmdbError(e)),
     }
 }
 
-pub struct Writer<'env, K> where K: AsRef<[u8]> {
+pub struct Writer<'env, K>
+where
+    K: AsRef<[u8]>,
+{
     tx: RwTransaction<'env>,
     db: Database,
     phantom: PhantomData<K>,
 }
 
-pub struct Reader<'env, K> where K: AsRef<[u8]> {
+pub struct Reader<'env, K>
+where
+    K: AsRef<[u8]>,
+{
     tx: RoTransaction<'env>,
     db: Database,
     phantom: PhantomData<K>,
@@ -64,7 +63,10 @@ pub struct Iter<'env> {
     cursor: RoCursor<'env>,
 }
 
-impl<'env, K> Writer<'env, K> where K: AsRef<[u8]> {
+impl<'env, K> Writer<'env, K>
+where
+    K: AsRef<[u8]>,
+{
     pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
         let bytes = self.tx.get(self.db, &k.as_ref());
         read_transform(bytes)
@@ -103,7 +105,10 @@ impl<'env, K> Writer<'env, K> where K: AsRef<[u8]> {
     }
 }
 
-impl<'env, K> Reader<'env, K> where K: AsRef<[u8]> {
+impl<'env, K> Reader<'env, K>
+where
+    K: AsRef<[u8]>,
+{
     pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
         let bytes = self.tx.get(self.db, &k.as_ref());
         read_transform(bytes)
@@ -114,7 +119,10 @@ impl<'env, K> Reader<'env, K> where K: AsRef<[u8]> {
     }
 
     pub fn iter_start<'s>(&'s self) -> Result<Iter<'s>, StoreError> {
-        let mut cursor = self.tx.open_ro_cursor(self.db).map_err(StoreError::LmdbError)?;
+        let mut cursor = self
+            .tx
+            .open_ro_cursor(self.db)
+            .map_err(StoreError::LmdbError)?;
 
         // We call Cursor.iter() instead of Cursor.iter_start() because
         // the latter panics at "called `Result::unwrap()` on an `Err` value:
@@ -133,7 +141,10 @@ impl<'env, K> Reader<'env, K> where K: AsRef<[u8]> {
     }
 
     pub fn iter_from<'s>(&'s self, k: K) -> Result<Iter<'s>, StoreError> {
-        let mut cursor = self.tx.open_ro_cursor(self.db).map_err(StoreError::LmdbError)?;
+        let mut cursor = self
+            .tx
+            .open_ro_cursor(self.db)
+            .map_err(StoreError::LmdbError)?;
         let iter = cursor.iter_from(k);
         Ok(Iter {
             iter: iter,
@@ -154,12 +165,18 @@ impl<'env> Iterator for Iter<'env> {
 }
 
 /// Wrapper around an `lmdb::Database`.
-pub struct Store<K> where K: AsRef<[u8]> {
+pub struct Store<K>
+where
+    K: AsRef<[u8]>,
+{
     db: Database,
     phantom: PhantomData<K>,
 }
 
-impl<K> Store<K> where K: AsRef<[u8]> {
+impl<K> Store<K>
+where
+    K: AsRef<[u8]>,
+{
     pub fn new(db: Database) -> Store<K> {
         Store {
             db: db,
@@ -187,7 +204,11 @@ impl<K> Store<K> where K: AsRef<[u8]> {
         })
     }
 
-    pub fn get<'env, 'tx>(&self, tx: &'tx RoTransaction<'env>, k: K) -> Result<Option<Value<'tx>>, StoreError> {
+    pub fn get<'env, 'tx>(
+        &self,
+        tx: &'tx RoTransaction<'env>,
+        k: K,
+    ) -> Result<Option<Value<'tx>>, StoreError> {
         let bytes = tx.get(self.db, &k.as_ref());
         read_transform(bytes)
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -11,9 +11,9 @@
 use ordered_float::OrderedFloat;
 
 use bincode::{
-    Infinite,
     deserialize,
     serialize,
+    Infinite,
 };
 
 use uuid::{
@@ -30,15 +30,15 @@ use error::DataError;
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum Type {
-    Bool    = 1,
-    U64     = 2,
-    I64     = 3,
-    F64     = 4,
-    Instant = 5,    // Millisecond-precision timestamp.
-    Uuid    = 6,
-    Str     = 7,
-    Json    = 8,
-    Blob    = 9,
+    Bool = 1,
+    U64 = 2,
+    I64 = 3,
+    F64 = 4,
+    Instant = 5, // Millisecond-precision timestamp.
+    Uuid = 6,
+    Str = 7,
+    Json = 8,
+    Blob = 9,
 }
 
 /// We use manual tagging, because <https://github.com/serde-rs/serde/issues/610>.
@@ -70,15 +70,15 @@ impl Type {
 impl ::std::fmt::Display for Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         f.write_str(match *self {
-            Type::Bool    => "bool",
-            Type::U64     => "u64",
-            Type::I64     => "i64",
-            Type::F64     => "f64",
+            Type::Bool => "bool",
+            Type::U64 => "u64",
+            Type::I64 => "i64",
+            Type::F64 => "f64",
             Type::Instant => "instant",
-            Type::Uuid    => "uuid",
-            Type::Str     => "str",
-            Type::Json    => "json",
-            Type::Blob    => "blob",
+            Type::Uuid => "uuid",
+            Type::Str => "str",
+            Type::Json => "json",
+            Type::Blob => "blob",
         })
     }
 }
@@ -89,7 +89,7 @@ pub enum Value<'s> {
     U64(u64),
     I64(i64),
     F64(OrderedFloat<f64>),
-    Instant(i64),    // Millisecond-precision timestamp.
+    Instant(i64), // Millisecond-precision timestamp.
     Uuid(&'s UuidBytes),
     Str(&'s str),
     Json(&'s str),
@@ -103,10 +103,10 @@ enum OwnedValue {
     U64(u64),
     I64(i64),
     F64(f64),
-    Instant(i64),    // Millisecond-precision timestamp.
+    Instant(i64), // Millisecond-precision timestamp.
     Uuid(Uuid),
     Str(String),
-    Json(String),    // TODO
+    Json(String), // TODO
     Blob(Vec<u8>),
 }
 
@@ -123,7 +123,10 @@ impl<'s> Value<'s> {
         let (tag, data) = slice.split_first().ok_or(DataError::Empty)?;
         let t = Type::from_tag(*tag)?;
         if t == expected {
-            return Err(DataError::UnexpectedType { expected: expected, actual: t });
+            return Err(DataError::UnexpectedType {
+                expected: expected,
+                actual: t,
+            });
         }
         Value::from_type_and_data(t, data)
     }
@@ -136,72 +139,47 @@ impl<'s> Value<'s> {
 
     fn from_type_and_data(t: Type, data: &'s [u8]) -> Result<Value<'s>, DataError> {
         if t == Type::Uuid {
-            return deserialize(data).map_err(|e| DataError::DecodingError { value_type: t, err: e })
-                                    .map(uuid)?;
+            return deserialize(data)
+                .map_err(|e| DataError::DecodingError {
+                    value_type: t,
+                    err: e,
+                })
+                .map(uuid)?;
         }
 
         match t {
-            Type::Bool => {
-                deserialize(data).map(Value::Bool)
-            },
-            Type::U64 => {
-                deserialize(data).map(Value::U64)
-            },
-            Type::I64 => {
-                deserialize(data).map(Value::I64)
-            },
-            Type::F64 => {
-                deserialize(data).map(OrderedFloat).map(Value::F64)
-            },
-            Type::Instant => {
-                deserialize(data).map(Value::Instant)
-            },
-            Type::Str => {
-                deserialize(data).map(Value::Str)
-            },
-            Type::Json => {
-                deserialize(data).map(Value::Json)
-            },
-            Type::Blob => {
-                deserialize(data).map(Value::Blob)
-            },
+            Type::Bool => deserialize(data).map(Value::Bool),
+            Type::U64 => deserialize(data).map(Value::U64),
+            Type::I64 => deserialize(data).map(Value::I64),
+            Type::F64 => deserialize(data).map(OrderedFloat).map(Value::F64),
+            Type::Instant => deserialize(data).map(Value::Instant),
+            Type::Str => deserialize(data).map(Value::Str),
+            Type::Json => deserialize(data).map(Value::Json),
+            Type::Blob => deserialize(data).map(Value::Blob),
             Type::Uuid => {
                 // Processed above to avoid verbose duplication of error transforms.
                 unreachable!()
-            },
-        }.map_err(|e| DataError::DecodingError { value_type: t, err: e })
+            }
+        }.map_err(|e| DataError::DecodingError {
+            value_type: t,
+            err: e,
+        })
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
         match self {
-            &Value::Bool(ref v) => {
-                serialize(&(Type::Bool.to_tag(), *v), Infinite)
-            },
-            &Value::U64(ref v) => {
-                serialize(&(Type::U64.to_tag(), *v), Infinite)
-            },
-            &Value::I64(ref v) => {
-                serialize(&(Type::I64.to_tag(), *v), Infinite)
-            },
-            &Value::F64(ref v) => {
-                serialize(&(Type::F64.to_tag(), v.0), Infinite)
-            },
-            &Value::Instant(ref v) => {
-                serialize(&(Type::Instant.to_tag(), *v), Infinite)
-            },
-            &Value::Str(ref v) => {
-                serialize(&(Type::Str.to_tag(), v), Infinite)
-            },
-            &Value::Json(ref v) => {
-                serialize(&(Type::Json.to_tag(), v), Infinite)
-            },
-            &Value::Blob(ref v) => {
-                serialize(&(Type::Blob.to_tag(), v), Infinite)
-            },
+            &Value::Bool(ref v) => serialize(&(Type::Bool.to_tag(), *v), Infinite),
+            &Value::U64(ref v) => serialize(&(Type::U64.to_tag(), *v), Infinite),
+            &Value::I64(ref v) => serialize(&(Type::I64.to_tag(), *v), Infinite),
+            &Value::F64(ref v) => serialize(&(Type::F64.to_tag(), v.0), Infinite),
+            &Value::Instant(ref v) => serialize(&(Type::Instant.to_tag(), *v), Infinite),
+            &Value::Str(ref v) => serialize(&(Type::Str.to_tag(), v), Infinite),
+            &Value::Json(ref v) => serialize(&(Type::Json.to_tag(), v), Infinite),
+            &Value::Blob(ref v) => serialize(&(Type::Blob.to_tag(), v), Infinite),
             &Value::Uuid(ref v) => {
                 // Processed above to avoid verbose duplication of error transforms.
                 serialize(&(Type::Uuid.to_tag(), v), Infinite)
-            },
+            }
         }.map_err(DataError::EncodingError)
     }
 }

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -12,31 +12,46 @@ extern crate rkv;
 extern crate tempfile;
 
 use rkv::{
-	Manager,
-	Rkv,
+    Manager,
+    Rkv,
 };
 
-use self::tempfile::{
-    Builder,
-};
+use self::tempfile::Builder;
 
 use std::fs;
 
-use std::sync::{
-    Arc,
-};
+use std::sync::Arc;
 
 #[test]
 // Identical to the same-named unit test, but this one confirms that it works
 // via the public MANAGER singleton.
 fn test_same() {
-    let root = Builder::new().prefix("test_same_singleton").tempdir().expect("tempdir");
+    let root = Builder::new()
+        .prefix("test_same_singleton")
+        .tempdir()
+        .expect("tempdir");
     fs::create_dir_all(root.path()).expect("dir created");
 
     let p = root.path();
-    assert!(Manager::singleton().read().unwrap().get(p).expect("success").is_none());
+    assert!(
+        Manager::singleton()
+            .read()
+            .unwrap()
+            .get(p)
+            .expect("success")
+            .is_none()
+    );
 
-    let created_arc = Manager::singleton().write().unwrap().get_or_create(p, Rkv::new).expect("created");
-    let fetched_arc = Manager::singleton().read().unwrap().get(p).expect("success").expect("existed");
+    let created_arc = Manager::singleton()
+        .write()
+        .unwrap()
+        .get_or_create(p, Rkv::new)
+        .expect("created");
+    let fetched_arc = Manager::singleton()
+        .read()
+        .unwrap()
+        .get(p)
+        .expect("success")
+        .expect("existed");
     assert!(Arc::ptr_eq(&created_arc, &fetched_arc));
 }


### PR DESCRIPTION
Formatted by rustfmt, only added one option to rustfmt.toml to favor the current [import indent](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md#vertical-1).

Although, it still flattened the single import from `use::foo::{Bar}` to `use::foo::Bar` :/