### PR TITLE
add appveyor for CI on windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+    platform: x64
+  - TARGET: i686-pc-windows-msvc
+    platform: x86
+
+install:
+  - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init.exe -y --default-host %TARGET%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+# Disable AppVeyor's build phase, let 'cargo test' take care of the build
+build: false
+
+test_script:
+- cargo test --all --target %TARGET%


### PR DESCRIPTION
This enables CI for windows on AppVeyor, which would require us to set up some stuff on AppVeyor.

Already tried it with my fork, the code appears to be broken on Windows due to the "UNC" path issue, will fix that in another follow up pr.

r? @mykmelez 