### PR TITLE
workaround unc path on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ lazy_static = "1.0"
 lmdb = "0.7"
 ordered-float = "0.5"
 uuid = "0.5"
-
 serde = "1.0"
+url = "1.7.0"
 
 # Get rid of failure's dependency on backtrace. Eventually
 # backtrace will move into Rust core, but we don't need it here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate lmdb;
 extern crate ordered_float;
 extern crate serde;               // So we can specify trait bounds. Everything else is bincode.
 extern crate uuid;
+extern crate url;
 
 pub use lmdb::{
     DatabaseFlags,


### PR DESCRIPTION
Workaround the UNC path on Windows, all the tests passed in the current stable toolchain "stable-x86_64-pc-windows-msvc"

Note that:
* It can't handle the paths longer than MAX_PATH
* It can't handle the paths with the non-utf8 characters

@mykmelez 
