### PR TITLE
enable rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+imports_layout = "Vertical"
+max_width = 120
+match_block_trailing_comma = true
+use_small_heuristics = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 rust:
   - stable
   - beta
@@ -7,3 +8,11 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+before_script:
+  - rustup toolchain install nightly
+  - rustup component add rustfmt-preview --toolchain nightly
+  - command -v rustfmt || cargo install --force rustfmt-nightly
+script:
+  - cargo +nightly fmt --all -- --check
+  - cargo build --verbose
+  - cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ It aims to achieve the following:
 
 If you specify the `backtrace` feature, backtraces will be enabled in `failure`
 errors. This feature is disabled by default.
+
+## Contributing
+
+rkv relies on the latest [rustfmt](https://github.com/rust-lang-nursery/rustfmt) for code formatting, please make sure your pull request passes the rustfmt before submitting it for review. See rustfmt's [quick start](https://github.com/rust-lang-nursery/rustfmt#quick-start) for installation details.

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -27,11 +27,7 @@ fn main() {
     fs::create_dir_all(root.path()).unwrap();
     let p = root.path();
 
-    let created_arc = Manager::singleton()
-        .write()
-        .unwrap()
-        .get_or_create(p, Rkv::new)
-        .unwrap();
+    let created_arc = Manager::singleton().write().unwrap().get_or_create(p, Rkv::new).unwrap();
     let k = created_arc.read().unwrap();
     let store: Store<&str> = k.create_or_open("store").unwrap();
 

--- a/examples/simple-store.rs
+++ b/examples/simple-store.rs
@@ -10,7 +10,12 @@
 extern crate rkv;
 extern crate tempfile;
 
-use rkv::{Manager, Rkv, Store, Value};
+use rkv::{
+    Manager,
+    Rkv,
+    Store,
+    Value,
+};
 use tempfile::Builder;
 
 use std::fs;
@@ -21,11 +26,7 @@ fn main() {
     let p = root.path();
 
     // The manager enforces that each process opens the same lmdb environment at most once
-    let created_arc = Manager::singleton()
-        .write()
-        .unwrap()
-        .get_or_create(p, Rkv::new)
-        .unwrap();
+    let created_arc = Manager::singleton().write().unwrap().get_or_create(p, Rkv::new).unwrap();
     let k = created_arc.read().unwrap();
 
     // Creates a store called "store"
@@ -38,14 +39,10 @@ fn main() {
         writer.put("int", &Value::I64(1234)).unwrap();
         writer.put("uint", &Value::U64(1234_u64)).unwrap();
         writer.put("float", &Value::F64(1234.0.into())).unwrap();
-        writer
-            .put("instant", &Value::Instant(1528318073700))
-            .unwrap();
+        writer.put("instant", &Value::Instant(1528318073700)).unwrap();
         writer.put("boolean", &Value::Bool(true)).unwrap();
         writer.put("string", &Value::Str("héllo, yöu")).unwrap();
-        writer
-            .put("json", &Value::Json(r#"{"foo":"bar", "number": 1}"#))
-            .unwrap();
+        writer.put("json", &Value::Json(r#"{"foo":"bar", "number": 1}"#)).unwrap();
         writer.put("blob", &Value::Blob(b"blob")).unwrap();
         writer.commit().unwrap();
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -8,9 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use std::os::raw::{
-    c_uint,
-};
+use std::os::raw::c_uint;
 
 use std::path::{
     Path,
@@ -27,18 +25,14 @@ use lmdb::{
     RwTransaction,
 };
 
-use error::{
-    StoreError,
-};
+use error::StoreError;
 
 use integer::{
     IntegerStore,
     PrimitiveInt,
 };
 
-use readwrite::{
-    Store,
-};
+use readwrite::Store;
 
 pub static DEFAULT_MAX_DBS: c_uint = 5;
 
@@ -63,12 +57,10 @@ impl Rkv {
 
         Ok(Rkv {
             path: path.into(),
-            env: env.open(path)
-                    .map_err(|e|
-                        match e {
-                            lmdb::Error::Other(2) => StoreError::DirectoryDoesNotExistError(path.into()),
-                            e => StoreError::LmdbError(e),
-                        })?,
+            env: env.open(path).map_err(|e| match e {
+                lmdb::Error::Other(2) => StoreError::DirectoryDoesNotExistError(path.into()),
+                e => StoreError::LmdbError(e),
+            })?,
         })
     }
 
@@ -98,33 +90,37 @@ impl Rkv {
     }
 
     pub fn create_or_open<'s, T, K>(&self, name: T) -> Result<Store<K>, StoreError>
-    where T: Into<Option<&'s str>>,
-          K: AsRef<[u8]> {
+    where
+        T: Into<Option<&'s str>>,
+        K: AsRef<[u8]>,
+    {
         let flags = DatabaseFlags::empty();
         self.create_or_open_with_flags(name, flags)
     }
 
     pub fn create_or_open_integer<'s, T, K>(&self, name: T) -> Result<IntegerStore<K>, StoreError>
-    where T: Into<Option<&'s str>>,
-          K: PrimitiveInt {
+    where
+        T: Into<Option<&'s str>>,
+        K: PrimitiveInt,
+    {
         let mut flags = DatabaseFlags::empty();
         flags.toggle(lmdb::INTEGER_KEY);
-        let db = self.env.create_db(name.into(), flags)
-                         .map_err(|e| match e {
-                             lmdb::Error::BadRslot => StoreError::open_during_transaction(),
-                             _ => e.into(),
-                         })?;
+        let db = self.env.create_db(name.into(), flags).map_err(|e| match e {
+            lmdb::Error::BadRslot => StoreError::open_during_transaction(),
+            _ => e.into(),
+        })?;
         Ok(IntegerStore::new(db))
     }
 
     pub fn create_or_open_with_flags<'s, T, K>(&self, name: T, flags: DatabaseFlags) -> Result<Store<K>, StoreError>
-    where T: Into<Option<&'s str>>,
-          K: AsRef<[u8]> {
-        let db = self.env.create_db(name.into(), flags)
-                         .map_err(|e| match e {
-                             lmdb::Error::BadRslot => StoreError::open_during_transaction(),
-                             _ => e.into(),
-                         })?;
+    where
+        T: Into<Option<&'s str>>,
+        K: AsRef<[u8]>,
+    {
+        let db = self.env.create_db(name.into(), flags).map_err(|e| match e {
+            lmdb::Error::BadRslot => StoreError::open_during_transaction(),
+            _ => e.into(),
+        })?;
         Ok(Store::new(db))
     }
 }
@@ -142,17 +138,15 @@ impl Rkv {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
     extern crate byteorder;
+    extern crate tempfile;
 
     use self::byteorder::{
         ByteOrder,
         LittleEndian,
     };
 
-    use self::tempfile::{
-        Builder,
-    };
+    use self::tempfile::Builder;
 
     use std::{
         fs,
@@ -160,7 +154,7 @@ mod tests {
     };
 
     use super::*;
-    use ::*;
+    use *;
 
     /// We can't open a directory that doesn't exist.
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,16 +8,12 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use std::path::{
-    PathBuf,
-};
+use std::path::PathBuf;
 
 use bincode;
 use lmdb;
 
-use value::{
-    Type,
-};
+use value::Type;
 
 #[derive(Debug, Fail)]
 pub enum DataError {

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -8,13 +8,11 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use std::marker::{
-    PhantomData,
-};
+use std::marker::PhantomData;
 
 use bincode::{
-    Infinite,
     serialize,
+    Infinite,
 };
 
 use lmdb::{
@@ -22,18 +20,14 @@ use lmdb::{
     RoTransaction,
 };
 
-use serde::{
-    Serialize,
-};
+use serde::Serialize;
 
 use error::{
     DataError,
     StoreError,
 };
 
-use value::{
-    Value,
-};
+use value::Value;
 
 use readwrite::{
     Reader,
@@ -41,8 +35,7 @@ use readwrite::{
     Writer,
 };
 
-use ::Rkv;
-
+use Rkv;
 
 pub trait EncodableKey {
     fn to_bytes(&self) -> Result<Vec<u8>, DataError>;
@@ -52,7 +45,10 @@ pub trait PrimitiveInt: EncodableKey {}
 
 impl PrimitiveInt for u32 {}
 
-impl<T> EncodableKey for T where T: Serialize {
+impl<T> EncodableKey for T
+where
+    T: Serialize,
+{
     fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
         serialize(self, Infinite)         // TODO: limited key length.
         .map_err(|e| e.into())
@@ -64,13 +60,19 @@ struct Key<K> {
     phantom: PhantomData<K>,
 }
 
-impl<K> AsRef<[u8]> for Key<K> where K: EncodableKey {
+impl<K> AsRef<[u8]> for Key<K>
+where
+    K: EncodableKey,
+{
     fn as_ref(&self) -> &[u8] {
         self.bytes.as_ref()
     }
 }
 
-impl<K> Key<K> where K: EncodableKey {
+impl<K> Key<K>
+where
+    K: EncodableKey,
+{
     fn new(k: K) -> Result<Key<K>, DataError> {
         Ok(Key {
             bytes: k.to_bytes()?,
@@ -79,15 +81,24 @@ impl<K> Key<K> where K: EncodableKey {
     }
 }
 
-pub struct IntegerStore<K> where K: PrimitiveInt {
+pub struct IntegerStore<K>
+where
+    K: PrimitiveInt,
+{
     inner: Store<Key<K>>,
 }
 
-pub struct IntegerReader<'env, K> where K: PrimitiveInt {
+pub struct IntegerReader<'env, K>
+where
+    K: PrimitiveInt,
+{
     inner: Reader<'env, Key<K>>,
 }
 
-impl<'env, K> IntegerReader<'env, K> where K: PrimitiveInt {
+impl<'env, K> IntegerReader<'env, K>
+where
+    K: PrimitiveInt,
+{
     pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
         self.inner.get(Key::new(k)?)
     }
@@ -97,11 +108,17 @@ impl<'env, K> IntegerReader<'env, K> where K: PrimitiveInt {
     }
 }
 
-pub struct IntegerWriter<'env, K> where K: PrimitiveInt {
+pub struct IntegerWriter<'env, K>
+where
+    K: PrimitiveInt,
+{
     inner: Writer<'env, Key<K>>,
 }
 
-impl<'env, K> IntegerWriter<'env, K> where K: PrimitiveInt {
+impl<'env, K> IntegerWriter<'env, K>
+where
+    K: PrimitiveInt,
+{
     pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
         self.inner.get(Key::new(k)?)
     }
@@ -115,7 +132,10 @@ impl<'env, K> IntegerWriter<'env, K> where K: PrimitiveInt {
     }
 }
 
-impl<K> IntegerStore<K> where K: PrimitiveInt {
+impl<K> IntegerStore<K>
+where
+    K: PrimitiveInt,
+{
     pub fn new(db: Database) -> IntegerStore<K> {
         IntegerStore {
             inner: Store::new(db),
@@ -144,9 +164,7 @@ impl<K> IntegerStore<K> where K: PrimitiveInt {
 mod tests {
     extern crate tempfile;
 
-    use self::tempfile::{
-        Builder,
-    };
+    use self::tempfile::Builder;
     use std::fs;
 
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,19 @@
 
 #![allow(dead_code)]
 
-#[macro_use] extern crate arrayref;
-#[macro_use] extern crate failure;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate arrayref;
+#[macro_use]
+extern crate failure;
+#[macro_use]
+extern crate lazy_static;
 
 extern crate bincode;
 extern crate lmdb;
 extern crate ordered_float;
-extern crate serde;               // So we can specify trait bounds. Everything else is bincode.
-extern crate uuid;
+extern crate serde; // So we can specify trait bounds. Everything else is bincode.
 extern crate url;
+extern crate uuid;
 
 pub use lmdb::{
     DatabaseFlags,
@@ -28,16 +31,14 @@ pub use lmdb::{
     WriteFlags,
 };
 
-pub mod value;
-pub mod error;
 mod env;
-mod readwrite;
+pub mod error;
 mod integer;
 mod manager;
+mod readwrite;
+pub mod value;
 
-pub use env::{
-    Rkv,
-};
+pub use env::Rkv;
 
 pub use error::{
     DataError,
@@ -49,16 +50,12 @@ pub use integer::{
     PrimitiveInt,
 };
 
-pub use manager::{
-    Manager
-};
+pub use manager::Manager;
 
 pub use readwrite::{
     Reader,
-    Writer,
     Store,
+    Writer,
 };
 
-pub use value::{
-    Value,
-};
+pub use value::Value;

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -10,9 +10,7 @@
 
 use lmdb;
 
-use std::marker::{
-    PhantomData,
-};
+use std::marker::PhantomData;
 
 use lmdb::{
     Cursor,
@@ -24,36 +22,35 @@ use lmdb::{
     Transaction,
 };
 
-use lmdb::{
-    WriteFlags,
-};
+use lmdb::WriteFlags;
 
-use error::{
-    StoreError,
-};
+use error::StoreError;
 
-use value::{
-    Value,
-};
+use value::Value;
 
-use ::Rkv;
+use Rkv;
 
 fn read_transform<'x>(val: Result<&'x [u8], lmdb::Error>) -> Result<Option<Value<'x>>, StoreError> {
     match val {
-        Ok(bytes) => Value::from_tagged_slice(bytes).map(Some)
-                                                    .map_err(StoreError::DataError),
+        Ok(bytes) => Value::from_tagged_slice(bytes).map(Some).map_err(StoreError::DataError),
         Err(lmdb::Error::NotFound) => Ok(None),
         Err(e) => Err(StoreError::LmdbError(e)),
     }
 }
 
-pub struct Writer<'env, K> where K: AsRef<[u8]> {
+pub struct Writer<'env, K>
+where
+    K: AsRef<[u8]>,
+{
     tx: RwTransaction<'env>,
     db: Database,
     phantom: PhantomData<K>,
 }
 
-pub struct Reader<'env, K> where K: AsRef<[u8]> {
+pub struct Reader<'env, K>
+where
+    K: AsRef<[u8]>,
+{
     tx: RoTransaction<'env>,
     db: Database,
     phantom: PhantomData<K>,
@@ -64,7 +61,10 @@ pub struct Iter<'env> {
     cursor: RoCursor<'env>,
 }
 
-impl<'env, K> Writer<'env, K> where K: AsRef<[u8]> {
+impl<'env, K> Writer<'env, K>
+where
+    K: AsRef<[u8]>,
+{
     pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
         let bytes = self.tx.get(self.db, &k.as_ref());
         read_transform(bytes)
@@ -74,15 +74,11 @@ impl<'env, K> Writer<'env, K> where K: AsRef<[u8]> {
     pub fn put<'s>(&'s mut self, k: K, v: &Value) -> Result<(), StoreError> {
         // TODO: don't allocate twice.
         let bytes = v.to_bytes()?;
-        self.tx
-            .put(self.db, &k.as_ref(), &bytes, WriteFlags::empty())
-            .map_err(StoreError::LmdbError)
+        self.tx.put(self.db, &k.as_ref(), &bytes, WriteFlags::empty()).map_err(StoreError::LmdbError)
     }
 
     pub fn delete<'s>(&'s mut self, k: K) -> Result<(), StoreError> {
-        self.tx
-            .del(self.db, &k.as_ref(), None)
-            .map_err(StoreError::LmdbError)
+        self.tx.del(self.db, &k.as_ref(), None).map_err(StoreError::LmdbError)
     }
 
     pub fn delete_value<'s>(&'s mut self, _k: K, _v: &Value) -> Result<(), StoreError> {
@@ -103,7 +99,10 @@ impl<'env, K> Writer<'env, K> where K: AsRef<[u8]> {
     }
 }
 
-impl<'env, K> Reader<'env, K> where K: AsRef<[u8]> {
+impl<'env, K> Reader<'env, K>
+where
+    K: AsRef<[u8]>,
+{
     pub fn get<'s>(&'s self, k: K) -> Result<Option<Value<'s>>, StoreError> {
         let bytes = self.tx.get(self.db, &k.as_ref());
         read_transform(bytes)
@@ -154,12 +153,18 @@ impl<'env> Iterator for Iter<'env> {
 }
 
 /// Wrapper around an `lmdb::Database`.
-pub struct Store<K> where K: AsRef<[u8]> {
+pub struct Store<K>
+where
+    K: AsRef<[u8]>,
+{
     db: Database,
     phantom: PhantomData<K>,
 }
 
-impl<K> Store<K> where K: AsRef<[u8]> {
+impl<K> Store<K>
+where
+    K: AsRef<[u8]>,
+{
     pub fn new(db: Database) -> Store<K> {
         Store {
             db: db,

--- a/src/value.rs
+++ b/src/value.rs
@@ -11,9 +11,9 @@
 use ordered_float::OrderedFloat;
 
 use bincode::{
-    Infinite,
     deserialize,
     serialize,
+    Infinite,
 };
 
 use uuid::{
@@ -30,15 +30,15 @@ use error::DataError;
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum Type {
-    Bool    = 1,
-    U64     = 2,
-    I64     = 3,
-    F64     = 4,
-    Instant = 5,    // Millisecond-precision timestamp.
-    Uuid    = 6,
-    Str     = 7,
-    Json    = 8,
-    Blob    = 9,
+    Bool = 1,
+    U64 = 2,
+    I64 = 3,
+    F64 = 4,
+    Instant = 5, // Millisecond-precision timestamp.
+    Uuid = 6,
+    Str = 7,
+    Json = 8,
+    Blob = 9,
 }
 
 /// We use manual tagging, because <https://github.com/serde-rs/serde/issues/610>.
@@ -70,15 +70,15 @@ impl Type {
 impl ::std::fmt::Display for Type {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         f.write_str(match *self {
-            Type::Bool    => "bool",
-            Type::U64     => "u64",
-            Type::I64     => "i64",
-            Type::F64     => "f64",
+            Type::Bool => "bool",
+            Type::U64 => "u64",
+            Type::I64 => "i64",
+            Type::F64 => "f64",
             Type::Instant => "instant",
-            Type::Uuid    => "uuid",
-            Type::Str     => "str",
-            Type::Json    => "json",
-            Type::Blob    => "blob",
+            Type::Uuid => "uuid",
+            Type::Str => "str",
+            Type::Json => "json",
+            Type::Blob => "blob",
         })
     }
 }
@@ -89,7 +89,7 @@ pub enum Value<'s> {
     U64(u64),
     I64(i64),
     F64(OrderedFloat<f64>),
-    Instant(i64),    // Millisecond-precision timestamp.
+    Instant(i64), // Millisecond-precision timestamp.
     Uuid(&'s UuidBytes),
     Str(&'s str),
     Json(&'s str),
@@ -103,10 +103,10 @@ enum OwnedValue {
     U64(u64),
     I64(i64),
     F64(f64),
-    Instant(i64),    // Millisecond-precision timestamp.
+    Instant(i64), // Millisecond-precision timestamp.
     Uuid(Uuid),
     Str(String),
-    Json(String),    // TODO
+    Json(String), // TODO
     Blob(Vec<u8>),
 }
 
@@ -123,7 +123,10 @@ impl<'s> Value<'s> {
         let (tag, data) = slice.split_first().ok_or(DataError::Empty)?;
         let t = Type::from_tag(*tag)?;
         if t == expected {
-            return Err(DataError::UnexpectedType { expected: expected, actual: t });
+            return Err(DataError::UnexpectedType {
+                expected: expected,
+                actual: t,
+            });
         }
         Value::from_type_and_data(t, data)
     }
@@ -136,68 +139,43 @@ impl<'s> Value<'s> {
 
     fn from_type_and_data(t: Type, data: &'s [u8]) -> Result<Value<'s>, DataError> {
         if t == Type::Uuid {
-            return deserialize(data).map_err(|e| DataError::DecodingError { value_type: t, err: e })
-                                    .map(uuid)?;
+            return deserialize(data)
+                .map_err(|e| DataError::DecodingError {
+                    value_type: t,
+                    err: e,
+                })
+                .map(uuid)?;
         }
 
         match t {
-            Type::Bool => {
-                deserialize(data).map(Value::Bool)
-            },
-            Type::U64 => {
-                deserialize(data).map(Value::U64)
-            },
-            Type::I64 => {
-                deserialize(data).map(Value::I64)
-            },
-            Type::F64 => {
-                deserialize(data).map(OrderedFloat).map(Value::F64)
-            },
-            Type::Instant => {
-                deserialize(data).map(Value::Instant)
-            },
-            Type::Str => {
-                deserialize(data).map(Value::Str)
-            },
-            Type::Json => {
-                deserialize(data).map(Value::Json)
-            },
-            Type::Blob => {
-                deserialize(data).map(Value::Blob)
-            },
+            Type::Bool => deserialize(data).map(Value::Bool),
+            Type::U64 => deserialize(data).map(Value::U64),
+            Type::I64 => deserialize(data).map(Value::I64),
+            Type::F64 => deserialize(data).map(OrderedFloat).map(Value::F64),
+            Type::Instant => deserialize(data).map(Value::Instant),
+            Type::Str => deserialize(data).map(Value::Str),
+            Type::Json => deserialize(data).map(Value::Json),
+            Type::Blob => deserialize(data).map(Value::Blob),
             Type::Uuid => {
                 // Processed above to avoid verbose duplication of error transforms.
                 unreachable!()
             },
-        }.map_err(|e| DataError::DecodingError { value_type: t, err: e })
+        }.map_err(|e| DataError::DecodingError {
+            value_type: t,
+            err: e,
+        })
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
         match self {
-            &Value::Bool(ref v) => {
-                serialize(&(Type::Bool.to_tag(), *v), Infinite)
-            },
-            &Value::U64(ref v) => {
-                serialize(&(Type::U64.to_tag(), *v), Infinite)
-            },
-            &Value::I64(ref v) => {
-                serialize(&(Type::I64.to_tag(), *v), Infinite)
-            },
-            &Value::F64(ref v) => {
-                serialize(&(Type::F64.to_tag(), v.0), Infinite)
-            },
-            &Value::Instant(ref v) => {
-                serialize(&(Type::Instant.to_tag(), *v), Infinite)
-            },
-            &Value::Str(ref v) => {
-                serialize(&(Type::Str.to_tag(), v), Infinite)
-            },
-            &Value::Json(ref v) => {
-                serialize(&(Type::Json.to_tag(), v), Infinite)
-            },
-            &Value::Blob(ref v) => {
-                serialize(&(Type::Blob.to_tag(), v), Infinite)
-            },
+            &Value::Bool(ref v) => serialize(&(Type::Bool.to_tag(), *v), Infinite),
+            &Value::U64(ref v) => serialize(&(Type::U64.to_tag(), *v), Infinite),
+            &Value::I64(ref v) => serialize(&(Type::I64.to_tag(), *v), Infinite),
+            &Value::F64(ref v) => serialize(&(Type::F64.to_tag(), v.0), Infinite),
+            &Value::Instant(ref v) => serialize(&(Type::Instant.to_tag(), *v), Infinite),
+            &Value::Str(ref v) => serialize(&(Type::Str.to_tag(), v), Infinite),
+            &Value::Json(ref v) => serialize(&(Type::Json.to_tag(), v), Infinite),
+            &Value::Blob(ref v) => serialize(&(Type::Blob.to_tag(), v), Infinite),
             &Value::Uuid(ref v) => {
                 // Processed above to avoid verbose duplication of error transforms.
                 serialize(&(Type::Uuid.to_tag(), v), Infinite)

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -12,19 +12,15 @@ extern crate rkv;
 extern crate tempfile;
 
 use rkv::{
-	Manager,
-	Rkv,
+    Manager,
+    Rkv,
 };
 
-use self::tempfile::{
-    Builder,
-};
+use self::tempfile::Builder;
 
 use std::fs;
 
-use std::sync::{
-    Arc,
-};
+use std::sync::Arc;
 
 #[test]
 // Identical to the same-named unit test, but this one confirms that it works


### PR DESCRIPTION
This replaces PR #32 in order to avoid those excessive merge conflicts. Also this adds various rustfmt configuration items based on the code review. Lastly, rustfmt check is enabled in TravisCi.

r? @mykmelez Could you take another look? You may notice there are a few long lines in this PR, since we've relaxed the `max_length` up to 120 characters, rustfmt decided to join some short lines to a a one-liner :). We can further tweak it around until we feel they're reasonable enough to get started. 