### PR TITLE
use specific rustfmt nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - rust: nightly
   fast_finish: true
 before_script:
-  - rustup toolchain install nightly
+  - rustup toolchain install nightly-2018-06-18
   - rustup component add rustfmt-preview --toolchain nightly
   - command -v rustfmt || cargo install --force rustfmt-nightly
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - rustup component add rustfmt-preview --toolchain nightly-2018-06-18
   - command -v rustfmt || cargo install --force rustfmt-nightly
 script:
-  - cargo +nightly fmt --all -- --check
+  - cargo +nightly-2018-06-18 fmt --all -- --check
   - cargo build --verbose
   - cargo test --verbose
   - ./run-all-examples.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   fast_finish: true
 before_script:
   - rustup toolchain install nightly-2018-06-18
-  - rustup component add rustfmt-preview --toolchain nightly
+  - rustup component add rustfmt-preview --toolchain nightly-2018-06-18
   - command -v rustfmt || cargo install --force rustfmt-nightly
 script:
   - cargo +nightly fmt --all -- --check


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/51699 has broken the nightly Rust toolchain. Our Travis configuration allows failures when building with that toolchain, but we use nightly rustfmt when building with all toolchains, so the bustage affects our stable and beta builds too.

To work around the problem, this branch uses a specific rustfmt nightly rather than the latest one. (We might want to keep doing this even after the bustage is fixed, to avoid such bustage in the future.)