### PR TITLE
fix listing/docs issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,13 @@
 name = "rkv"
 version = "0.3.1"
 authors = ["Richard Newman <rnewman@twinql.com>"]
-description = "A humane key-value store built on LMDB."
+description = "a simple, humane, typed Rust interface to LMDB"
 license = "Apache-2.0"
-homepage = "https://github.com/mozilla-prototypes/rkv"
-repository = "https://github.com/mozilla-prototypes/rkv"
+homepage = "https://github.com/mozilla/rkv"
+repository = "https://github.com/mozilla/rkv"
+readme = "README.md"
+keywords = ["lmdb", "database", "storage"]
+categories = ["database"]
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@
 //! It aims to achieve the following:
 //!
 //! - Avoid LMDB's sharp edges (e.g., obscure error codes for common situations).
-//! - Report errors via [failure](../failure/index.html).
+//! - Report errors via [failure](https://docs.rs/failure/).
 //! - Correctly restrict access to one handle per process via a [Manager](struct.Manager.html).
 //! - Use Rust's type system to make single-typed key stores (including LMDB's own integer-keyed stores) safe and ergonomic.
-//! - Encode and decode values via [bincode](../bincode/index.html)/[serde](../serde/index.html)
+//! - Encode and decode values via [bincode](https://docs.rs/bincode/)/[serde](https://docs.rs/serde/)
 //!   and type tags, achieving platform-independent storage and input/output flexibility.
 //!
 //! It exposes these primary abstractions:


### PR DESCRIPTION
@ncalexan After publishing a new version of rkv this morning, I noticed some issues with the crates.io listing and the docs you reviewed yesterday. Here's a set of fixes for them. I also added keywords and a category, and I updated the repo URL.
