### PR TITLE
fix various clippy nits

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -79,7 +79,7 @@ impl From<lmdb::Error> for StoreError {
     fn from(e: lmdb::Error) -> StoreError {
         match e {
             lmdb::Error::BadRslot => StoreError::ReadTransactionAlreadyExists(::std::thread::current().id()),
-            e @ _ => StoreError::LmdbError(e),
+            e => StoreError::LmdbError(e),
         }
     }
 }

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -136,8 +136,8 @@ where
         let iter = cursor.iter();
 
         Ok(Iter {
-            iter: iter,
-            cursor: cursor,
+            iter,
+            cursor,
         })
     }
 
@@ -145,8 +145,8 @@ where
         let mut cursor = self.tx.open_ro_cursor(store.db).map_err(StoreError::LmdbError)?;
         let iter = cursor.iter_from(k);
         Ok(Iter {
-            iter: iter,
-            cursor: cursor,
+            iter,
+            cursor,
         })
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -123,7 +123,7 @@ impl<'s> Value<'s> {
         let t = Type::from_tag(*tag)?;
         if t == expected {
             return Err(DataError::UnexpectedType {
-                expected: expected,
+                expected,
                 actual: t,
             });
         }
@@ -167,15 +167,15 @@ impl<'s> Value<'s> {
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
         match self {
-            &Value::Bool(ref v) => serialize(&(Type::Bool.to_tag(), *v)),
-            &Value::U64(ref v) => serialize(&(Type::U64.to_tag(), *v)),
-            &Value::I64(ref v) => serialize(&(Type::I64.to_tag(), *v)),
-            &Value::F64(ref v) => serialize(&(Type::F64.to_tag(), v.0)),
-            &Value::Instant(ref v) => serialize(&(Type::Instant.to_tag(), *v)),
-            &Value::Str(ref v) => serialize(&(Type::Str.to_tag(), v)),
-            &Value::Json(ref v) => serialize(&(Type::Json.to_tag(), v)),
-            &Value::Blob(ref v) => serialize(&(Type::Blob.to_tag(), v)),
-            &Value::Uuid(ref v) => {
+            Value::Bool(ref v) => serialize(&(Type::Bool.to_tag(), *v)),
+            Value::U64(ref v) => serialize(&(Type::U64.to_tag(), *v)),
+            Value::I64(ref v) => serialize(&(Type::I64.to_tag(), *v)),
+            Value::F64(ref v) => serialize(&(Type::F64.to_tag(), v.0)),
+            Value::Instant(ref v) => serialize(&(Type::Instant.to_tag(), *v)),
+            Value::Str(ref v) => serialize(&(Type::Str.to_tag(), v)),
+            Value::Json(ref v) => serialize(&(Type::Json.to_tag(), v)),
+            Value::Blob(ref v) => serialize(&(Type::Blob.to_tag(), v)),
+            Value::Uuid(ref v) => {
                 // Processed above to avoid verbose duplication of error transforms.
                 serialize(&(Type::Uuid.to_tag(), v))
             },


### PR DESCRIPTION
Had a chance to try out rust-clippy, it reported a few nits and code simplifications that seemed legit.

Didn't take its suggestion of `explicit lifetimes given in parameter types where they could be elided` though, I figure perhaps those life time tags were annotated there intentionally. 