### PR TITLE
derive Copy for Store (fix #29)

### DIFF
--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -163,6 +163,7 @@ impl<'env> Iterator for Iter<'env> {
 }
 
 /// Wrapper around an `lmdb::Database`.
+#[derive(Copy, Clone)]
 pub struct Store {
     db: Database,
 }

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -162,7 +162,8 @@ impl<'env> Iterator for Iter<'env> {
     }
 }
 
-/// Wrapper around an `lmdb::Database`.
+/// Wrapper around an `lmdb::Database`.  At this time, the underlying LMDB
+/// handle (within lmdb-rs::Database) is a C integer, so Copy is automatic.
 #[derive(Copy, Clone)]
 pub struct Store {
     db: Database,


### PR DESCRIPTION
@ncalexan Per @rnewman's comment https://github.com/mozilla/rkv/pull/28#issuecomment-395448738, Store can be Copy, and access to it doesn't need to be synchronized, as described by #29. So this branch derives Copy for Store and tests access to it by multiple threads.
