### PR TITLE
correct instructions for running tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,14 @@ errors. This feature is disabled by default.
 Test this project as you would test other Rust crates:
 
 ```sh
-cargo test --tests
+cargo test
 ```
 
-The project includes unit tests embedded in the `src/` files, integration tests in the `tests/` subdirectory, and usage examples in the `examples/` subdirectory. To ensure your changes don't break examples, specify `--tests` when running tests to run both unit/integration tests and example binaries.
+The project includes unit and doc tests embedded in the `src/` files, integration tests in the `tests/` subdirectory, and usage examples in the `examples/` subdirectory. To ensure your changes don't break examples, also run them via the run-all-examples.sh shell script:
+
+```sh
+./run-all-examples.sh
+```
 
 ## Contribute
 


### PR DESCRIPTION
The README currently suggests that `cargo test --tests` will run both unit/integration tests and example binaries. That's incorrect, as it'll only run the former. And it skips doc tests.

To run unit, integration, and doc tests, we need to run `cargo test` (no flag). And to run the example binaries, we need to use the run-all-examples.sh shell script, as there's no cargo command that will run all those (`cargo run --example [name]` runs only the specified test, and `cargo test -examples` runs only unit tests within the example binaries).
