### PR TITLE
switch lmdb-rs dependency to mozilla/lmdb-rs fork (fix #70)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ backtrace = ["failure/backtrace", "failure/std"]
 arrayref = "0.3"
 bincode = "1.0"
 lazy_static = "1.0"
-lmdb = "0.8"
+lmdb = { git = "https://github.com/mozilla/lmdb-rs", branch = "rkv" }
 new-ordered-float = "1.0"
 uuid = "0.5"
 serde = "1.0"

--- a/src/env.rs
+++ b/src/env.rs
@@ -661,7 +661,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: NotFound")]
     fn test_iter_from_key_greater_than_existing() {
         let root = Builder::new().prefix("test_iter_from_key_greater_than_existing").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
@@ -676,15 +675,8 @@ mod tests {
         writer.commit().expect("committed");
 
         let reader = k.read().unwrap();
-
-        // There is no key greater than "nuu", so the underlying LMDB API panics
-        // when calling iter_from.  This is unfortunate, and I've requested
-        // https://github.com/danburkert/lmdb-rs/pull/29 to make the underlying
-        // API return a Result instead.
-        //
-        // Also see alternative https://github.com/danburkert/lmdb-rs/pull/30.
-        //
-        reader.iter_from(&sk, "nuu").unwrap();
+        let mut iter = reader.iter_from(&sk, "nuu").unwrap();
+        assert!(iter.next().is_none());
     }
 
     #[test]


### PR DESCRIPTION
Per #70, we should switch from the crates.io package to the [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs) fork of the lmdb crate, where we've taken fixes for rkv.

I'd rather not publish [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs) to a new crates.io package, which'd require a different (but presumably similar) name, sow confusion about the differences between the two crates, and potentially complicate unforking in the future.

Instead, I'd like to point rkv's lmdb dependency to [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs) via its Cargo.toml file's [dependencies] section, which is a paved cow path, f.e. in https://searchfox.org/mozilla-central/source/gfx/wrench/Cargo.toml, where Gecko does that for yaml-rust and osmesa-src.

Another option would be to override rkv's lmdb dependency via a patch, as https://searchfox.org/mozilla-central/source/Cargo.toml does for serde_derive. That could avoid depending on two incompatible versions of the crate, as described in https://github.com/rust-lang-nursery/failure/issues/230#issuecomment-408664012 and following comments. But I don't think that's an issue in this case, as I don't expect Gecko's crate dependency tree to include another dependency on lmdb.

Thus I think the best option is for rkv to depend on [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs) via its Cargo.toml file's [dependencies] section, and that's what I've done in this branch.

I've further specified that rkv should depend on the "rkv" branch of [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs), to ensure we're explicit about upgrading the dependency. (Otherwise, any change to [mozilla/lmdb-rs](https://github.com/mozilla/lmdb-rs)'s master branch would implicitly upgrade the dependency, which feels brittle.)

@ncalexan I'm requesting review from you at an architectural level, not a code level (as the code changes are trivial), to get a sanity check on this plan!
