### PR TITLE
increment patch version to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkv"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Richard Newman <rnewman@twinql.com>"]
 description = "a simple, humane, typed Rust interface to LMDB"
 license = "Apache-2.0"


### PR DESCRIPTION
For the (backward-compatible) change to the lmdb-rkv crate dependency.