### PR TITLE
test exceeding and increasing the map size

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -277,6 +277,19 @@ mod tests {
         let _zzz = k.open_or_create("zzz").expect("opened");
     }
 
+    fn get_larger_than_default_map_size_value() -> usize {
+        // The LMDB C library and lmdb Rust crate docs for setting the map size
+        // <http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5>
+        // <https://docs.rs/lmdb/0.8.0/lmdb/struct.EnvironmentBuilder.html#method.set_map_size>
+        // both say that the default map size is 10,485,760 bytes, i.e. 10MiB.
+        //
+        // But the DEFAULT_MAPSIZE define in the LMDB code
+        // https://github.com/LMDB/lmdb/blob/26c7df88e44e31623d0802a564f24781acdefde3/libraries/liblmdb/mdb.c#L729
+        // sets the default map size to 1,048,576 bytes, i.e. 1MiB.
+        //
+        1024 * 1024 + 1 /* 1,048,576 + 1 bytes, i.e. 1MiB + 1 byte */
+    }
+
     #[test]
     #[should_panic(expected = "wrote: LmdbError(MapFull)")]
     fn test_exceed_map_size() {
@@ -289,20 +302,8 @@ mod tests {
         let sk: Store = k.open_or_create_default().expect("opened");
 
         // Writing a large enough value should cause LMDB to fail on MapFull.
-        //
-        // The LMDB C library and lmdb Rust crate docs for setting the map size
-        // <http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5>
-        // <https://docs.rs/lmdb/0.8.0/lmdb/struct.EnvironmentBuilder.html#method.set_map_size>
-        // both say that the default map size is 10,485,760 bytes, i.e. 10MiB.
-        //
-        // But the DEFAULT_MAPSIZE define in the LMDB code
-        // https://github.com/LMDB/lmdb/blob/26c7df88e44e31623d0802a564f24781acdefde3/libraries/liblmdb/mdb.c#L729
-        // sets the default map size to 1,048,576 bytes, i.e. 1MiB.
-        //
-        // So we write a 1MiB string to the database, which should take a bit
-        // more space than that (for the key, the type, etc.), thus triggering
-        // the failure.
-        let val = "x".repeat(1024 * 1024 /* 1,048,576 bytes, i.e. 1MiB */);
+        // We write a string that is larger than the default map size.
+        let val = "x".repeat(get_larger_than_default_map_size_value());
         let mut writer = k.write().expect("writer");
         writer.put(&sk, "foo", &Value::Str(&val)).expect("wrote");
     }
@@ -315,21 +316,19 @@ mod tests {
         assert!(root.path().is_dir());
 
         let mut builder = Rkv::environment_builder();
-        builder.set_map_size(1024 * 1024 * 10 /* 10,485,760 bytes, i.e. 10MiB */);
+        // Set the map size to the size of the value we'll store in it + 100KiB,
+        // which ensures that there's enough space for the value and metadata.
+        builder.set_map_size(get_larger_than_default_map_size_value() + 100 * 1024 /* 100KiB */);
         let k = Rkv::from_env(root.path(), builder).unwrap();
         let sk: Store = k.open_or_create_default().expect("opened");
-        let val = "x".repeat(1024 * 1024 /* 1,048,576 bytes, i.e. 1MiB */);
+        let val = "x".repeat(get_larger_than_default_map_size_value());
 
         let mut writer = k.write().expect("writer");
         writer.put(&sk, "foo", &Value::Str(&val)).expect("wrote");
-        writer.put(&sk, "bar", &Value::Str(&val)).expect("wrote");
-        writer.put(&sk, "baz", &Value::Str(&val)).expect("wrote");
         writer.commit().expect("committed");
 
         let reader = k.read().unwrap();
         assert_eq!(reader.get(&sk, "foo").expect("read"), Some(Value::Str(&val)));
-        assert_eq!(reader.get(&sk, "bar").expect("read"), Some(Value::Str(&val)));
-        assert_eq!(reader.get(&sk, "baz").expect("read"), Some(Value::Str(&val)));
     }
 
     #[test]


### PR DESCRIPTION
Per the comment from @shivawu in #34 that there should be a way to set an environment's map size, here are tests that demonstrate how to do that.

NB: We should file upstream bugs/PRs in the LMDB crate and C library to fix the code or docs (probably the latter) to agree about the default map size for an LMDB environment.
