### PR TITLE
implement conversion from Value to OwnedValue and expose OwnedValue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "1.0"
 lazy_static = "1.0"
 lmdb-rkv = "0.8"
 ordered-float = "1.0"
-uuid = "0.6"
+uuid = "0.7"
 serde = "1.0"
 url = "1.7.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,4 +218,7 @@ pub use readwrite::{
     Writer,
 };
 
-pub use value::Value;
+pub use value::{
+    OwnedValue,
+    Value,
+};

--- a/src/value.rs
+++ b/src/value.rs
@@ -180,10 +180,6 @@ impl<'s> Value<'s> {
             },
         }.map_err(DataError::EncodingError)
     }
-
-    pub fn to_owned(&self) -> OwnedValue {
-        self.into()
-    }
 }
 
 impl<'s> From<&'s Value<'s>> for OwnedValue {

--- a/src/value.rs
+++ b/src/value.rs
@@ -16,8 +16,8 @@ use bincode::{
 };
 
 use uuid::{
-    Uuid,
     Bytes,
+    Uuid,
 };
 
 use error::DataError;

--- a/src/value.rs
+++ b/src/value.rs
@@ -17,7 +17,7 @@ use bincode::{
 
 use uuid::{
     Uuid,
-    UuidBytes,
+    Bytes,
 };
 
 use error::DataError;
@@ -89,15 +89,14 @@ pub enum Value<'s> {
     I64(i64),
     F64(OrderedFloat<f64>),
     Instant(i64), // Millisecond-precision timestamp.
-    Uuid(&'s UuidBytes),
+    Uuid(&'s Bytes),
     Str(&'s str),
     Json(&'s str),
     Blob(&'s [u8]),
 }
 
-// TODO: implement conversion between the two types of `Value` wrapper.
-// This might be unnecessary: we'll probably jump straight to primitives.
-enum OwnedValue {
+#[derive(Debug, PartialEq)]
+pub enum OwnedValue {
     Bool(bool),
     U64(u64),
     I64(i64),
@@ -180,5 +179,19 @@ impl<'s> Value<'s> {
                 serialize(&(Type::Uuid.to_tag(), v))
             },
         }.map_err(DataError::EncodingError)
+    }
+
+    pub fn to_owned(&self) -> OwnedValue {
+        match self {
+            Value::Bool(ref v) => OwnedValue::Bool(*v),
+            Value::U64(ref v) => OwnedValue::U64(*v),
+            Value::I64(ref v) => OwnedValue::I64(*v),
+            Value::F64(ref v) => OwnedValue::F64(**v),
+            Value::Instant(ref v) => OwnedValue::Instant(*v),
+            Value::Uuid(ref v) => OwnedValue::Uuid(Uuid::from_bytes(**v)),
+            Value::Str(ref v) => OwnedValue::Str(v.to_string()),
+            Value::Json(ref v) => OwnedValue::Json(v.to_string()),
+            Value::Blob(ref v) => OwnedValue::Blob(v.to_vec()),
+        }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -182,7 +182,13 @@ impl<'s> Value<'s> {
     }
 
     pub fn to_owned(&self) -> OwnedValue {
-        match self {
+        self.into()
+    }
+}
+
+impl<'s> From<&'s Value<'s>> for OwnedValue {
+    fn from(value: &Value) -> OwnedValue {
+        match value {
             Value::Bool(ref v) => OwnedValue::Bool(*v),
             Value::U64(ref v) => OwnedValue::U64(*v),
             Value::I64(ref v) => OwnedValue::I64(*v),


### PR DESCRIPTION
There's this comment on the OwnedValue implementation:

> // TODO: implement conversion between the two types of `Value` wrapper.
> // This might be unnecessary: we'll probably jump straight to primitives.

However, I've identified a use case: in Gecko, structs that implement an XPCOM interface may want to store a `Value`, but they can't hold a reference, because the XPCOM Rust binding doesn't support that; so they would need to store an `OwnedValue` instead (or generalize over the primitive type and make their consumers convert the reference types to owned types).

This branch implements the `Value` to `OwnedValue` conversion for storage in XPCOM structs (and any other unknown unknown use cases out there).

It also upgrades the uuid dependency from 0.6 to 0.7, which isn't strictly necessary but allows us to make the conversion infallible, since the `Value::Uuid` to `OwnedValue::Uuid` conversion calls `Uuid::from_bytes()`, which is [fallible (at runtime)](https://docs.rs/uuid/0.6.5/uuid/struct.Uuid.html#method.from_bytes) in version 0.6 but [infallible (at runtime, fails at compile-time)](https://docs.rs/uuid/0.7.1/uuid/struct.Uuid.html#method.from_bytes) in version 0.7.
