### PR TITLE
update version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkv"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Richard Newman <rnewman@twinql.com>"]
 description = "a simple, humane, typed Rust interface to LMDB"
 license = "Apache-2.0"


### PR DESCRIPTION
This release includes a dependency update from uuid version 0.6 to 0.7, which is a breaking change, since we exposed uuid 0.6's `UuidBytes` type, which has been replaced with the `Bytes` type in uuid 0.7.

Thus I'm bumping the rkv version from 0.5.1 to 0.6.0 (rather than 0.5.2, which is what it would have been otherwise).
