### PR TITLE
update minor version to 0.7.0 for breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkv"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Richard Newman <rnewman@twinql.com>", "Nan Jiang <najiang@mozilla.com>", "Myk Melez <myk@mykzilla.org>"]
 description = "a simple, humane, typed Rust interface to LMDB"
 license = "Apache-2.0"


### PR DESCRIPTION
43a8731ff86f7d3110ec492e9ddd6031a655d8d8 converts Store to a newtype and passes it by value, which is a breaking change to the public API.