### PR TITLE
fix 'cargo fmt' nits; use latest nightly for 'cargo fmt'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
     - rust: nightly
   fast_finish: true
 before_script:
-  - rustup toolchain install nightly-2018-07-18
-  - rustup component add rustfmt-preview --toolchain nightly-2018-07-18
+  - rustup toolchain install nightly
+  - rustup component add rustfmt-preview --toolchain nightly
   - command -v rustfmt || cargo install --force rustfmt-nightly
 script:
-  - cargo +nightly-2018-07-18 fmt --all -- --check
+  - cargo +nightly fmt --all -- --check
   - cargo build --verbose
   - cargo test --verbose
   - ./run-all-examples.sh

--- a/src/env.rs
+++ b/src/env.rs
@@ -522,7 +522,8 @@ mod tests {
         let mut existing = match writer.get(sk, "foo").expect("read") {
             Some(Value::Str(val)) => val,
             _ => "",
-        }.to_string();
+        }
+        .to_string();
         existing.push('…');
         writer.put(sk, "foo", &Value::Str(&existing)).expect("write");
         writer.commit().expect("commit");

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -42,7 +42,7 @@ where
     T: Serialize,
 {
     fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
-        serialize(self)         // TODO: limited key length.
+        serialize(self) // TODO: limited key length.
             .map_err(|e| e.into())
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -158,7 +158,8 @@ impl<'s> Value<'s> {
                 // Processed above to avoid verbose duplication of error transforms.
                 unreachable!()
             },
-        }.map_err(|e| DataError::DecodingError {
+        }
+        .map_err(|e| DataError::DecodingError {
             value_type: t,
             err: e,
         })
@@ -178,7 +179,8 @@ impl<'s> Value<'s> {
                 // Processed above to avoid verbose duplication of error transforms.
                 serialize(&(Type::Uuid.to_tag(), v))
             },
-        }.map_err(DataError::EncodingError)
+        }
+        .map_err(DataError::EncodingError)
     }
 }
 


### PR DESCRIPTION
We've let a few `cargo fmt` nits creep into the codebase, according to the latest nightly build of Rust. Here are the fixes.

This branch also changes back to using the latest nightly build of Rust to format the code, rather than a fixed/pinned build of nightly.

(We'd previously pinned the build because of Rust nightly build bustage, which is a risk when going back to using the latest nightly. Let's see how it goes and re-pin a build if it breaks too often.)
