### PR TITLE
test consumer-specified integer key variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ lmdb-rkv = "0.9"
 ordered-float = "1.0"
 uuid = "0.7"
 serde = "1.0"
+serde_derive = "1.0"
 url = "1.7.0"
 
 # Get rid of failure's dependency on backtrace. Eventually

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -160,18 +160,16 @@ mod tests {
         let s = k.open_or_create_integer("s").expect("open");
 
         macro_rules! test_integer_keys {
-            ($type:ty, $key:expr) => {
-                {
-                    let mut writer = k.write_int::<$type>().expect("writer");
+            ($type:ty, $key:expr) => {{
+                let mut writer = k.write_int::<$type>().expect("writer");
 
-                    writer.put(s, $key, &Value::Str("hello!")).expect("write");
-                    assert_eq!(writer.get(s, $key).expect("read"), Some(Value::Str("hello!")));
-                    writer.commit().expect("committed");
+                writer.put(s, $key, &Value::Str("hello!")).expect("write");
+                assert_eq!(writer.get(s, $key).expect("read"), Some(Value::Str("hello!")));
+                writer.commit().expect("committed");
 
-                    let reader = k.read_int::<$type>().expect("reader");
-                    assert_eq!(reader.get(s, $key).expect("read"), Some(Value::Str("hello!")));
-                }
-            }
+                let reader = k.read_int::<$type>().expect("reader");
+                assert_eq!(reader.get(s, $key).expect("read"), Some(Value::Str("hello!")));
+            }};
         }
 
         test_integer_keys!(u32, 123);

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -35,7 +35,9 @@ pub trait EncodableKey {
 
 pub trait PrimitiveInt: EncodableKey {}
 
+impl PrimitiveInt for u16 {}
 impl PrimitiveInt for u32 {}
+impl PrimitiveInt for u64 {}
 
 impl<T> EncodableKey for T
 where
@@ -124,11 +126,11 @@ where
         self.inner.put(store.0, Key::new(k)?, v)
     }
 
-    fn abort(self) {
+    pub fn abort(self) {
         self.inner.abort();
     }
 
-    fn commit(self) -> Result<(), StoreError> {
+    pub fn commit(self) -> Result<(), StoreError> {
         self.inner.commit()
     }
 }
@@ -172,15 +174,11 @@ mod tests {
             }};
         }
 
-        test_integer_keys!(u32, 123);
-
-        // The integer module provides only the u32 variant of IntegerStore,
-        // but consumers can use others by implementing PrimitiveInt for their
-        // desired type.  Here we implement and test PrimitiveInt for the i32
-        // and u64 types.
-        impl PrimitiveInt for i32 {}
-        impl PrimitiveInt for u64 {}
-        test_integer_keys!(u64, 123);
-        test_integer_keys!(i32, -123);
+        test_integer_keys!(u16, std::u16::MIN);
+        test_integer_keys!(u16, std::u16::MAX);
+        test_integer_keys!(u32, std::u32::MIN);
+        test_integer_keys!(u32, std::u32::MAX);
+        test_integer_keys!(u64, std::u64::MIN);
+        test_integer_keys!(u64, std::u64::MAX);
     }
 }

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -35,9 +35,7 @@ pub trait EncodableKey {
 
 pub trait PrimitiveInt: EncodableKey {}
 
-impl PrimitiveInt for u16 {}
 impl PrimitiveInt for u32 {}
-impl PrimitiveInt for u64 {}
 
 impl<T> EncodableKey for T
 where
@@ -174,11 +172,7 @@ mod tests {
             }};
         }
 
-        test_integer_keys!(u16, std::u16::MIN);
-        test_integer_keys!(u16, std::u16::MAX);
         test_integer_keys!(u32, std::u32::MIN);
         test_integer_keys!(u32, std::u32::MAX);
-        test_integer_keys!(u64, std::u64::MIN);
-        test_integer_keys!(u64, std::u64::MAX);
     }
 }

--- a/tests/integer-store.rs
+++ b/tests/integer-store.rs
@@ -45,23 +45,35 @@ fn test_integer_keys() {
         }};
     }
 
-    // The integer module provides u16, u32, and u64 integer key variants
-    // of IntegerStore, so we can use them without further ado.
-    test_integer_keys!(u16, std::u16::MIN);
-    test_integer_keys!(u16, std::u16::MAX);
+    // The integer module provides only the u32 integer key variant
+    // of IntegerStore, so we can use it without further ado.
     test_integer_keys!(u32, std::u32::MIN);
     test_integer_keys!(u32, std::u32::MAX);
-    test_integer_keys!(u64, std::u64::MIN);
-    test_integer_keys!(u64, std::u64::MAX);
 
-    // If we want to use another integer key variant, we need to implement
+    // If you want to use another integer key variant, you need to implement
     // a newtype, implement PrimitiveInt, and implement or derive Serialize
     // for it.  Here we do so for the i32 type.
+
+    // DANGER!  Doing this enables you to open a store with multiple,
+    // different integer key types, which may result in unexpected behavior.
+    // Make sure you know what you're doing!
 
     #[derive(Serialize)]
     struct I32(i32);
     impl PrimitiveInt for I32 {}
-
     test_integer_keys!(I32, I32(std::i32::MIN));
     test_integer_keys!(I32, I32(std::i32::MAX));
+
+    #[derive(Serialize)]
+    struct U16(u16);
+    impl PrimitiveInt for U16 {}
+    test_integer_keys!(U16, U16(std::u16::MIN));
+    test_integer_keys!(U16, U16(std::u16::MAX));
+
+    #[derive(Serialize)]
+    struct U64(u64);
+    impl PrimitiveInt for U64 {}
+    test_integer_keys!(U64, U64(std::u64::MIN));
+    test_integer_keys!(U64, U64(std::u64::MAX));
+
 }

--- a/tests/integer-store.rs
+++ b/tests/integer-store.rs
@@ -75,5 +75,4 @@ fn test_integer_keys() {
     impl PrimitiveInt for U64 {}
     test_integer_keys!(U64, U64(std::u64::MIN));
     test_integer_keys!(U64, U64(std::u64::MAX));
-
 }

--- a/tests/integer-store.rs
+++ b/tests/integer-store.rs
@@ -1,0 +1,67 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern crate bincode;
+extern crate rkv;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate tempfile;
+
+use rkv::{
+    PrimitiveInt,
+    Rkv,
+    Value,
+};
+
+use self::tempfile::Builder;
+
+use std::fs;
+
+#[test]
+fn test_integer_keys() {
+    let root = Builder::new().prefix("test_integer_keys").tempdir().expect("tempdir");
+    fs::create_dir_all(root.path()).expect("dir created");
+    let k = Rkv::new(root.path()).expect("new succeeded");
+    let s = k.open_or_create_integer("s").expect("open");
+
+    macro_rules! test_integer_keys {
+        ($type:ty, $key:expr) => {{
+            let mut writer = k.write_int::<$type>().expect("writer");
+
+            writer.put(s, $key, &Value::Str("hello!")).expect("write");
+            assert_eq!(writer.get(s, $key).expect("read"), Some(Value::Str("hello!")));
+            writer.commit().expect("committed");
+
+            let reader = k.read_int::<$type>().expect("reader");
+            assert_eq!(reader.get(s, $key).expect("read"), Some(Value::Str("hello!")));
+        }};
+    }
+
+    // The integer module provides u16, u32, and u64 integer key variants
+    // of IntegerStore, so we can use them without further ado.
+    test_integer_keys!(u16, std::u16::MIN);
+    test_integer_keys!(u16, std::u16::MAX);
+    test_integer_keys!(u32, std::u32::MIN);
+    test_integer_keys!(u32, std::u32::MAX);
+    test_integer_keys!(u64, std::u64::MIN);
+    test_integer_keys!(u64, std::u64::MAX);
+
+    // If we want to use another integer key variant, we need to implement
+    // a newtype, implement PrimitiveInt, and implement or derive Serialize
+    // for it.  Here we do so for the i32 type.
+
+    #[derive(Serialize)]
+    struct I32(i32);
+    impl PrimitiveInt for I32 {}
+
+    test_integer_keys!(I32, I32(std::i32::MIN));
+    test_integer_keys!(I32, I32(std::i32::MAX));
+}


### PR DESCRIPTION
@ncloudioj This just tests that we can generalize across integer types with generic type parameters. It contains only test changes, no functional changes. I created it to help think through the changes we're contemplating in #97, but it seems worth landing as well, to document (and verify) that this works.

Let me know what you think!
