### PR TITLE
remove unnecessary use declarations, self:: reference

### DIFF
--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -7,10 +7,7 @@
 //!
 //!     cargo run --example iterator
 
-use rkv;
-use tempfile;
-
-use self::rkv::{
+use rkv::{
     Manager,
     Rkv,
     Store,

--- a/examples/simple-store.rs
+++ b/examples/simple-store.rs
@@ -7,10 +7,7 @@
 //!
 //!     cargo run --example simple-store
 
-use rkv;
-use tempfile;
-
-use self::rkv::{
+use rkv::{
     Manager,
     Rkv,
     Value,


### PR DESCRIPTION
@rrichardson While reviewing #101, I realized that we can remove the `use rkv` and `use tempfile` declarations in examples/, as they're redundant with later declarations that import specific symbols from those crates.

Also, the `use self::rkv::{ … }` declaration happens to work because of the preceding `use rkv` declaration, but `self::` is intended to reference local modules/items, and rkv is actually an external crate in this case (from the perspective of the example, which demonstrates how an external consumer would use rkv).

So this followup branch removes the `use rkv` and `use tempfile` declarations and changes `use self::rkv::{ … }` to `use rkv::{ … }`.

Does this seem reasonable?
