### PR TITLE
require lazy_static version 1.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ backtrace = ["failure/backtrace", "failure/std"]
 [dependencies]
 arrayref = "0.3"
 bincode = "1.0"
-lazy_static = "1.0"
+lazy_static = "1.0.2"
 lmdb-rkv = "0.9"
 ordered-float = "1.0"
 uuid = "0.7"


### PR DESCRIPTION
Depending on rkv in a crate that also depends on lazy_static version 1.0.1 can cause the problem described in https://users.rust-lang.org/t/2018-edition-macro-ergonomics/18790 if the consumer causes rkv to also use lazy_static version 1.0.1. We should thus require that rkv use at least lazy_static 1.0.2.
