### PR TITLE
remove mut from the *store mutation functions as it is not needed

### DIFF
--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -59,7 +59,7 @@ fn main() {
     }
 }
 
-fn populate_store(k: &Rkv, mut store: SingleStore) -> Result<(), StoreError> {
+fn populate_store(k: &Rkv, store: SingleStore) -> Result<(), StoreError> {
     let mut writer = k.write()?;
     for (country, city) in vec![
         ("Canada", Value::Str("Ottawa")),

--- a/examples/simple-store.rs
+++ b/examples/simple-store.rs
@@ -20,7 +20,7 @@ use tempfile::Builder;
 
 use std::fs;
 
-fn getput<'env, 's>(mut store: MultiStore, writer: &'env mut RwTransaction, ids: &'s mut Vec<String>) {
+fn getput<'env, 's>(store: MultiStore, writer: &'env mut RwTransaction, ids: &'s mut Vec<String>) {
     let keys = vec!["str1", "str2", "str3"];
     // we convert the writer into a cursor so that we can safely read
     for k in keys.iter() {
@@ -39,7 +39,7 @@ fn getput<'env, 's>(mut store: MultiStore, writer: &'env mut RwTransaction, ids:
     }
 }
 
-fn delete<'env, 's>(mut store: MultiStore, writer: &'env mut RwTransaction) {
+fn delete<'env, 's>(store: MultiStore, writer: &'env mut RwTransaction) {
     let keys = vec!["str1", "str2", "str3"];
     let vals = vec!["string uno", "string quatro", "string siete"];
     // we convert the writer into a cursor so that we can safely read
@@ -58,9 +58,9 @@ fn main() {
     let k = created_arc.read().unwrap();
 
     // Creates a store called "store"
-    let mut store = k.open_single("store", StoreOptions::create()).unwrap();
+    let store = k.open_single("store", StoreOptions::create()).unwrap();
 
-    let mut multistore = k.open_multi("multistore", StoreOptions::create()).unwrap();
+    let multistore = k.open_multi("multistore", StoreOptions::create()).unwrap();
 
     println!("Inserting data...");
     {
@@ -156,7 +156,7 @@ fn main() {
 
     println!("Write and read on multiple stores...");
     {
-        let mut another_store = k.open_single("another_store", StoreOptions::create()).unwrap();
+        let another_store = k.open_single("another_store", StoreOptions::create()).unwrap();
         let mut writer = k.write().unwrap();
         store.put(&mut writer, "foo", &Value::Str("bar")).unwrap();
         another_store.put(&mut writer, "foo", &Value::Str("baz")).unwrap();

--- a/src/env.rs
+++ b/src/env.rs
@@ -311,7 +311,7 @@ mod tests {
         assert!(root.path().is_dir());
 
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut sk: SingleStore = k.open_single("test", StoreOptions::create()).expect("opened");
+        let sk: SingleStore = k.open_single("test", StoreOptions::create()).expect("opened");
 
         // Writing a large enough value should cause LMDB to fail on MapFull.
         // We write a string that is larger than the default map size.
@@ -333,7 +333,7 @@ mod tests {
         builder.set_map_size(get_larger_than_default_map_size_value() + 100 * 1024 /* 100KiB */);
         builder.set_max_dbs(2);
         let k = Rkv::from_env(root.path(), builder).unwrap();
-        let mut sk: SingleStore = k.open_single("test", StoreOptions::create()).expect("opened");
+        let  sk: SingleStore = k.open_single("test", StoreOptions::create()).expect("opened");
         let val = "x".repeat(get_larger_than_default_map_size_value());
 
         let mut writer = k.write().expect("writer");
@@ -350,7 +350,7 @@ mod tests {
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
 
-        let mut sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
+        let sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
 
         {
             let mut writer = k.write().expect("writer");
@@ -450,7 +450,7 @@ mod tests {
         let root = Builder::new().prefix("test_multi_put_get_del").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut multistore = k.open_multi("multistore", StoreOptions::create()).unwrap();
+        let multistore = k.open_multi("multistore", StoreOptions::create()).unwrap();
         let mut writer = k.write().unwrap();
         multistore.put(&mut writer, "str1", &Value::Str("str1 foo")).unwrap();
         multistore.put(&mut writer, "str1", &Value::Str("str1 bar")).unwrap();
@@ -481,7 +481,7 @@ mod tests {
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         // First create the store, and start a write transaction on it.
-        let mut sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
         let mut writer = k.write().expect("writer");
         sk.put(&mut writer, "foo", &Value::Str("bar")).expect("write");
 
@@ -525,7 +525,7 @@ mod tests {
         let root = Builder::new().prefix("test_read_before_write_num").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
+        let sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
 
         // Test reading a number, modifying it, and then writing it back.
         // We have to be done with the Value::I64 before calling Writer::put,
@@ -554,7 +554,7 @@ mod tests {
         let root = Builder::new().prefix("test_read_before_write_str").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
+        let sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
 
         // Test reading a string, modifying it, and then writing it back.
         // We have to be done with the Value::Str before calling Writer::put,
@@ -596,7 +596,7 @@ mod tests {
         let root = Builder::new().prefix("test_isolation").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut s: SingleStore = k.open_single("s", StoreOptions::create()).expect("opened");
+        let s: SingleStore = k.open_single("s", StoreOptions::create()).expect("opened");
 
         // Add one field.
         {
@@ -638,7 +638,7 @@ mod tests {
         let root = Builder::new().prefix("test_round_trip_blob").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
+        let sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
         let mut writer = k.write().expect("writer");
 
         assert_eq!(sk.get(&writer, "foo").expect("read"), None);
@@ -679,7 +679,7 @@ mod tests {
         builder.set_flags(EnvironmentFlags::NO_SYNC);
         {
             let k = Rkv::from_env(root.path(), builder).expect("new succeeded");
-            let mut sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
+            let sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
 
             {
                 let mut writer = k.write().expect("writer");
@@ -700,7 +700,7 @@ mod tests {
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
         for i in 0..5 {
-            let mut sk: IntegerStore<u32> =
+            let sk: IntegerStore<u32> =
                 k.open_integer(&format!("sk{}", i)[..], StoreOptions::create()).expect("opened");
             {
                 let mut writer = k.write().expect("writer");
@@ -719,7 +719,7 @@ mod tests {
         let root = Builder::new().prefix("test_iter").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
+        let sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
 
         // An iterator over an empty store returns no values.
         {
@@ -793,7 +793,7 @@ mod tests {
         let root = Builder::new().prefix("test_iter_from_key_greater_than_existing").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
+        let sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
 
         let mut writer = k.write().expect("writer");
         sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
@@ -813,9 +813,9 @@ mod tests {
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
 
-        let mut s1: SingleStore = k.open_single("store_1", StoreOptions::create()).expect("opened");
-        let mut s2: SingleStore = k.open_single("store_2", StoreOptions::create()).expect("opened");
-        let mut s3: SingleStore = k.open_single("store_3", StoreOptions::create()).expect("opened");
+        let s1: SingleStore = k.open_single("store_1", StoreOptions::create()).expect("opened");
+        let s2: SingleStore = k.open_single("store_2", StoreOptions::create()).expect("opened");
+        let s3: SingleStore = k.open_single("store_3", StoreOptions::create()).expect("opened");
 
         let mut writer = k.write().expect("writer");
         s1.put(&mut writer, "foo", &Value::Str("bar")).expect("wrote");
@@ -852,8 +852,8 @@ mod tests {
         let root = Builder::new().prefix("test_multiple_store_iter").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let k = Rkv::new(root.path()).expect("new succeeded");
-        let mut s1: SingleStore = k.open_single("store_1", StoreOptions::create()).expect("opened");
-        let mut s2: SingleStore = k.open_single("store_2", StoreOptions::create()).expect("opened");
+        let s1: SingleStore = k.open_single("store_1", StoreOptions::create()).expect("opened");
+        let s2: SingleStore = k.open_single("store_2", StoreOptions::create()).expect("opened");
 
         let mut writer = k.write().expect("writer");
         // Write to "s1"
@@ -964,7 +964,7 @@ mod tests {
         let root = Builder::new().prefix("test_multiple_thread").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
         let rkv_arc = Arc::new(RwLock::new(Rkv::new(root.path()).expect("new succeeded")));
-        let mut store = rkv_arc.read().unwrap().open_single("test", StoreOptions::create()).expect("opened");
+        let store = rkv_arc.read().unwrap().open_single("test", StoreOptions::create()).expect("opened");
 
         let num_threads = 10;
         let mut write_handles = Vec::with_capacity(num_threads as usize);

--- a/src/env.rs
+++ b/src/env.rs
@@ -333,7 +333,7 @@ mod tests {
         builder.set_map_size(get_larger_than_default_map_size_value() + 100 * 1024 /* 100KiB */);
         builder.set_max_dbs(2);
         let k = Rkv::from_env(root.path(), builder).unwrap();
-        let  sk: SingleStore = k.open_single("test", StoreOptions::create()).expect("opened");
+        let sk: SingleStore = k.open_single("test", StoreOptions::create()).expect("opened");
         let val = "x".repeat(get_larger_than_default_map_size_value());
 
         let mut writer = k.write().expect("writer");

--- a/src/store/integer.rs
+++ b/src/store/integer.rs
@@ -96,11 +96,11 @@ where
         self.inner.get(txn, Key::new(k)?)
     }
 
-    pub fn put(&mut self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
+    pub fn put(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
         self.inner.put(txn, Key::new(k)?, v)
     }
 
-    pub fn delete(&mut self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
+    pub fn delete(&self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
         self.inner.delete(txn, Key::new(k)?)
     }
 }

--- a/src/store/integermulti.rs
+++ b/src/store/integermulti.rs
@@ -58,12 +58,12 @@ where
         self.inner.get_first(txn, Key::new(k)?)
     }
 
-    pub fn put(&mut self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
+    pub fn put(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
         self.inner.put(txn, Key::new(k)?, v)
     }
 
     pub fn put_with_flags(
-        &mut self,
+        &self,
         txn: &mut RwTransaction,
         k: K,
         v: &Value,
@@ -72,11 +72,11 @@ where
         self.inner.put_with_flags(txn, Key::new(k)?, v, flags)
     }
 
-    pub fn delete_all(&mut self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
+    pub fn delete_all(&self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
         self.inner.delete_all(txn, Key::new(k)?)
     }
 
-    pub fn delete(&mut self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
+    pub fn delete(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
         self.inner.delete(txn, Key::new(k)?, v)
     }
 }

--- a/src/store/multi.rs
+++ b/src/store/multi.rs
@@ -84,13 +84,13 @@ impl MultiStore {
     /// Insert a value at the specified key.
     /// This put will allow duplicate entries.  If you wish to have duplicate entries
     /// rejected, use the `put_with_flags` function and specify NO_DUP_DATA
-    pub fn put<K: AsRef<[u8]>>(&mut self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
+    pub fn put<K: AsRef<[u8]>>(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
         let bytes = v.to_bytes()?;
         txn.put(self.db, &k, &bytes, WriteFlags::empty()).map_err(StoreError::LmdbError)
     }
 
     pub fn put_with_flags<K: AsRef<[u8]>>(
-        &mut self,
+        &self,
         txn: &mut RwTransaction,
         k: K,
         v: &Value,
@@ -100,11 +100,11 @@ impl MultiStore {
         txn.put(self.db, &k, &bytes, flags).map_err(StoreError::LmdbError)
     }
 
-    pub fn delete_all<K: AsRef<[u8]>>(&mut self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
+    pub fn delete_all<K: AsRef<[u8]>>(&self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
         txn.del(self.db, &k, None).map_err(StoreError::LmdbError)
     }
 
-    pub fn delete<K: AsRef<[u8]>>(&mut self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
+    pub fn delete<K: AsRef<[u8]>>(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
         txn.del(self.db, &k, Some(&v.to_bytes()?)).map_err(StoreError::LmdbError)
     }
 

--- a/src/store/single.rs
+++ b/src/store/single.rs
@@ -60,13 +60,13 @@ impl SingleStore {
     }
 
     // TODO: flags
-    pub fn put<K: AsRef<[u8]>>(&mut self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
+    pub fn put<K: AsRef<[u8]>>(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
         // TODO: don't allocate twice.
         let bytes = v.to_bytes()?;
         txn.put(self.db, &k, &bytes, WriteFlags::empty()).map_err(StoreError::LmdbError)
     }
 
-    pub fn delete<K: AsRef<[u8]>>(&mut self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
+    pub fn delete<K: AsRef<[u8]>>(&self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
         txn.del(self.db, &k, None).map_err(StoreError::LmdbError)
     }
 

--- a/tests/integer-store.rs
+++ b/tests/integer-store.rs
@@ -24,7 +24,7 @@ fn test_integer_keys() {
     let root = Builder::new().prefix("test_integer_keys").tempdir().expect("tempdir");
     fs::create_dir_all(root.path()).expect("dir created");
     let k = Rkv::new(root.path()).expect("new succeeded");
-    let mut s = k.open_integer("s", StoreOptions::create()).expect("open");
+    let s = k.open_integer("s", StoreOptions::create()).expect("open");
 
     macro_rules! test_integer_keys {
         ($store:expr, $key:expr) => {{
@@ -52,7 +52,7 @@ fn test_integer_keys() {
     // different integer key types, which may result in unexpected behavior.
     // Make sure you know what you're doing!
 
-    let mut t = k.open_integer("s", StoreOptions::create()).expect("open");
+    let t = k.open_integer("s", StoreOptions::create()).expect("open");
 
     #[derive(Serialize)]
     struct I32(i32);
@@ -60,7 +60,7 @@ fn test_integer_keys() {
     test_integer_keys!(t, I32(std::i32::MIN));
     test_integer_keys!(t, I32(std::i32::MAX));
 
-    let mut u = k.open_integer("s", StoreOptions::create()).expect("open");
+    let u = k.open_integer("s", StoreOptions::create()).expect("open");
 
     #[derive(Serialize)]
     struct U16(u16);
@@ -68,7 +68,7 @@ fn test_integer_keys() {
     test_integer_keys!(u, U16(std::u16::MIN));
     test_integer_keys!(u, U16(std::u16::MAX));
 
-    let mut v = k.open_integer("s", StoreOptions::create()).expect("open");
+    let v = k.open_integer("s", StoreOptions::create()).expect("open");
 
     #[derive(Serialize)]
     struct U64(u64);

--- a/tests/multi-integer-store.rs
+++ b/tests/multi-integer-store.rs
@@ -24,7 +24,7 @@ fn test_multi_integer_keys() {
     let root = Builder::new().prefix("test_integer_keys").tempdir().expect("tempdir");
     fs::create_dir_all(root.path()).expect("dir created");
     let k = Rkv::new(root.path()).expect("new succeeded");
-    let mut s = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+    let s = k.open_multi_integer("s", StoreOptions::create()).expect("open");
 
     macro_rules! test_integer_keys {
         ($store:expr, $key:expr) => {{
@@ -66,7 +66,7 @@ fn test_multi_integer_keys() {
     // different integer key types, which may result in unexpected behavior.
     // Make sure you know what you're doing!
 
-    let mut t = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+    let t = k.open_multi_integer("s", StoreOptions::create()).expect("open");
 
     #[derive(Serialize)]
     struct I32(i32);
@@ -74,7 +74,7 @@ fn test_multi_integer_keys() {
     test_integer_keys!(t, I32(std::i32::MIN));
     test_integer_keys!(t, I32(std::i32::MAX));
 
-    let mut u = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+    let u = k.open_multi_integer("s", StoreOptions::create()).expect("open");
 
     #[derive(Serialize)]
     struct U16(u16);
@@ -82,7 +82,7 @@ fn test_multi_integer_keys() {
     test_integer_keys!(u, U16(std::u16::MIN));
     test_integer_keys!(u, U16(std::u16::MAX));
 
-    let mut v = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+    let v = k.open_multi_integer("s", StoreOptions::create()).expect("open");
 
     #[derive(Serialize)]
     struct U64(u64);


### PR DESCRIPTION
Fixes the *Store put/del functions that took &mut self.  Changes everything to &self and removes the warnings from all code that consumes those methods. 