### PR TITLE
fix nits and docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,11 @@
 //! It exposes these primary abstractions:
 //!
 //! - [Manager](struct.Manager.html): a singleton that controls access to LMDB environments
-//! - [Rkv](struct.Rkv.html): an LMDB environment, which contains a set of key/value databases
-//! - [Store](struct.Store.html): an LMDB database, which contains a set of key/value pairs
+//! - [Rkv](struct.Rkv.html): an LMDB environment that contains a set of key/value databases
+//! - [SingleStore](store/single/struct.SingleStore.html): an LMDB database that contains a set of key/value pairs
 //!
 //! Keys can be anything that implements `AsRef<[u8]>` or integers
-//!  (when accessing an [IntegerStore](struct.IntegerStore.html)).
+//! (when accessing an [IntegerStore](store/integer/struct.IntegerStore.html)).
 //! Values can be any of the types defined by the [Value](value/enum.Value.html) enum, including:
 //!
 //! - booleans (`Value::Bool`)

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,6 +3,11 @@ pub mod integermulti;
 pub mod multi;
 pub mod single;
 
+use crate::{
+    error::StoreError,
+    value::OwnedValue,
+    value::Value,
+};
 use lmdb::DatabaseFlags;
 
 #[derive(Default, Debug, Copy, Clone)]
@@ -17,5 +22,21 @@ impl Options {
             create: true,
             flags: DatabaseFlags::empty(),
         }
+    }
+}
+
+fn read_transform(val: Result<&[u8], lmdb::Error>) -> Result<Option<Value>, StoreError> {
+    match val {
+        Ok(bytes) => Value::from_tagged_slice(bytes).map(Some).map_err(StoreError::DataError),
+        Err(lmdb::Error::NotFound) => Ok(None),
+        Err(e) => Err(StoreError::LmdbError(e)),
+    }
+}
+
+fn read_transform_owned(val: Result<&[u8], lmdb::Error>) -> Result<Option<OwnedValue>, StoreError> {
+    match val {
+        Ok(bytes) => Value::from_tagged_slice(bytes).map(|v| Some(OwnedValue::from(&v))).map_err(StoreError::DataError),
+        Err(lmdb::Error::NotFound) => Ok(None),
+        Err(e) => Err(StoreError::LmdbError(e)),
     }
 }

--- a/src/store/multi.rs
+++ b/src/store/multi.rs
@@ -51,7 +51,7 @@ impl MultiStore {
         })
     }
 
-    /// Provides a cursor to all of the values for the duplicate entries that match this key
+    /// Provides the first value that matches this key
     pub fn get_first<T: Transaction, K: AsRef<[u8]>>(self, txn: &T, k: K) -> Result<Option<Value>, StoreError> {
         let result = txn.get(self.db, &k);
         read_transform(result)

--- a/src/store/multi.rs
+++ b/src/store/multi.rs
@@ -8,8 +8,11 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use lmdb;
-
+use crate::{
+    error::StoreError,
+    store::read_transform,
+    value::Value,
+};
 use lmdb::{
     Cursor,
     Database,
@@ -20,29 +23,6 @@ use lmdb::{
     Transaction,
     WriteFlags,
 };
-
-use crate::error::StoreError;
-
-use crate::value::{
-    OwnedValue,
-    Value,
-};
-
-fn read_transform(val: Result<&[u8], lmdb::Error>) -> Result<Option<Value>, StoreError> {
-    match val {
-        Ok(bytes) => Value::from_tagged_slice(bytes).map(Some).map_err(StoreError::DataError),
-        Err(lmdb::Error::NotFound) => Ok(None),
-        Err(e) => Err(StoreError::LmdbError(e)),
-    }
-}
-
-fn read_transform_owned(val: Result<&[u8], lmdb::Error>) -> Result<Option<OwnedValue>, StoreError> {
-    match val {
-        Ok(bytes) => Value::from_tagged_slice(bytes).map(|v| Some(OwnedValue::from(&v))).map_err(StoreError::DataError),
-        Err(lmdb::Error::NotFound) => Ok(None),
-        Err(e) => Err(StoreError::LmdbError(e)),
-    }
-}
 
 #[derive(Copy, Clone)]
 pub struct MultiStore {
@@ -129,6 +109,14 @@ impl MultiStore {
 }
 
 /*
+fn read_transform_owned(val: Result<&[u8], lmdb::Error>) -> Result<Option<OwnedValue>, StoreError> {
+    match val {
+        Ok(bytes) => Value::from_tagged_slice(bytes).map(|v| Some(OwnedValue::from(&v))).map_err(StoreError::DataError),
+        Err(lmdb::Error::NotFound) => Ok(None),
+        Err(e) => Err(StoreError::LmdbError(e)),
+    }
+}
+
 impl<'env> Iterator for MultiIter<'env> {
     type Item = Iter<'env>;
 

--- a/src/store/single.rs
+++ b/src/store/single.rs
@@ -8,8 +8,11 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use lmdb;
-
+use crate::{
+    error::StoreError,
+    store::read_transform,
+    value::Value,
+};
 use lmdb::{
     Cursor,
     Database,
@@ -17,21 +20,8 @@ use lmdb::{
     RoCursor,
     RwTransaction,
     Transaction,
+    WriteFlags,
 };
-
-use lmdb::WriteFlags;
-
-use crate::error::StoreError;
-
-use crate::value::Value;
-
-fn read_transform(val: Result<&[u8], lmdb::Error>) -> Result<Option<Value>, StoreError> {
-    match val {
-        Ok(bytes) => Value::from_tagged_slice(bytes).map(Some).map_err(StoreError::DataError),
-        Err(lmdb::Error::NotFound) => Ok(None),
-        Err(e) => Err(StoreError::LmdbError(e)),
-    }
-}
 
 #[derive(Copy, Clone)]
 pub struct SingleStore {


### PR DESCRIPTION
This fixes a couple of the nits noted in #101. It also fixes the crate-level documentation in src/lib.rs, which contains some outdated references to documentation pages for the _Store_ and _IntegerStore_ types.
