### PR TITLE
update lmdb-rkv dependency and rkv minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkv"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Richard Newman <rnewman@twinql.com>", "Nan Jiang <najiang@mozilla.com>", "Myk Melez <myk@mykzilla.org>"]
 description = "a simple, humane, typed Rust interface to LMDB"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ backtrace = ["failure/backtrace", "failure/std"]
 arrayref = "0.3"
 bincode = "1.0"
 lazy_static = "1.0.2"
-lmdb-rkv = "0.11"
+lmdb-rkv = "0.11.1"
 ordered-float = "1.0"
 uuid = "0.7"
 serde = "1.0"


### PR DESCRIPTION
Updates lmdb-rkv dependency to latest stable version 0.11.1 (LMDB 0.9.23). Although this wasn't a breaking change (hence the patch version increment from 0.11.0 to 0.11.1), I think we do want to ensure that rkv consumers get the update to the latest stable LMDB version, which is why I've specified the patch version of the lmdb-rkv dependency.

This also updates rkv minor version to 0.9.0 in preparation for publishing a new version with recent breaking changes. I reviewed the three commits since 0.8.0 (a9f84809b43d3179d32951c652f205d7f8d4cc89, 9c8160f71da358e32f7a3e250049e8ff98a67d0e, 7390e6ff5d91b23b166b5c1e089923209c6f1b05), and they're almost entirely backward-compatible, as the changes are almost entirely additive.

But the change from `&self` to `self` for the first parameter of some methods in SingleStore and MultiStore is technically a breaking change. Consumers won't notice it most of the time, since Rust's dot operator does automatic dereferencing. But a consumer using the `::` operator to call a method would bypass that automation and break:

```rust
let store = SingleStore::new(…);
store.put(…); // doesn't break
SingleStore::put(&store, …); // breaks
```

So I think we need to rev the minor version of rkv instead of the patch version for this breaking change (even if it's unlikely to be encountered in the field). @ncloudioj Does that sound right to you as well?
