### PR TITLE
correct crate docs

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -163,10 +163,16 @@ impl Rkv {
 
 /// Read and write accessors.
 impl Rkv {
+    /// Create a read transaction.  There can be multiple concurrent readers
+    /// for an environment, up to the maximum specified by LMDB (default 126),
+    /// and you can open readers while a write transaction is active.
     pub fn read(&self) -> Result<RoTransaction, StoreError> {
         self.env.begin_ro_txn().map_err(|e| e.into())
     }
 
+    /// Create a write transaction.  There can be only one write transaction
+    /// active at any given time, so trying to create a second one will block
+    /// until the first is committed or aborted.
     pub fn write(&self) -> Result<RwTransaction, StoreError> {
         self.env.begin_rw_txn().map_err(|e| e.into())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,32 +58,30 @@
 //!
 //! // The Manager enforces that each process opens the same environment
 //! // at most once by caching a handle to each environment that it opens.
-//! // Retrieve the handle to an opened environment—or create one if it hasn't
-//! // already been opened—by calling `Manager.get_or_create()`, passing it
-//! // an `Rkv` method that opens an environment (`Rkv::new` in this case):
+//! // Use it to retrieve the handle to an opened environment—or create one
+//! // if it hasn't already been opened:
 //! let created_arc = Manager::singleton().write().unwrap().get_or_create(path, Rkv::new).unwrap();
 //! let env = created_arc.read().unwrap();
 //!
-//! // Call `Rkv.open_or_create_default()` to get a handle to the default
-//! // (unnamed) store for the environment.
+//! // Then you can use the environment handle to get a handle to a datastore:
 //! let mut store: SingleStore = env.open_single("mydb", StoreOptions::create()).unwrap();
 //!
 //! {
-//!     // Use a write transaction to mutate the store by calling
-//!     // `Rkv.write()` to create a `Writer`.  There can be only one
-//!     // writer for a given store; opening a second one will block
-//!     // until the first completes.
+//!     // Use a write transaction to mutate the store via a `Writer`.
+//!     // There can be only one writer for a given store; opening a second one
+//!     // will block until the first completes.
 //!     let mut writer = env.write().unwrap();
 //!
-//!     // Writer takes a `Store` as the first argument.
 //!     // Keys are `AsRef<[u8]>`, while values are `Value` enum instances.
 //!     // Use the `Blob` variant to store arbitrary collections of bytes.
+//!     // Putting data returns a `Result<(), StoreError>`, where StoreError
+//!     // is an enum identifying the reason for a failure.
 //!     store.put(&mut writer, "int", &Value::I64(1234)).unwrap();
 //!     store.put(&mut writer, "uint", &Value::U64(1234_u64)).unwrap();
 //!     store.put(&mut writer, "float", &Value::F64(1234.0.into())).unwrap();
 //!     store.put(&mut writer, "instant", &Value::Instant(1528318073700)).unwrap();
 //!     store.put(&mut writer, "boolean", &Value::Bool(true)).unwrap();
-//!     store.put(&mut writer, "string", &Value::Str("héllo, yöu")).unwrap();
+//!     store.put(&mut writer, "string", &Value::Str("Héllo, wörld!")).unwrap();
 //!     store.put(&mut writer, "json", &Value::Json(r#"{"foo":"bar", "number": 1}"#)).unwrap();
 //!     store.put(&mut writer, "blob", &Value::Blob(b"blob")).unwrap();
 //!
@@ -93,13 +91,12 @@
 //! }
 //!
 //! {
-//!     // Use a read transaction to query the store by calling `Rkv.read()`
-//!     // to create a `Reader`.  There can be unlimited concurrent readers
-//!     // for a store, and readers never block on a writer nor other readers.
+//!     // Use a read transaction to query the store via a `Reader`.
+//!     // There can be unlimited concurrent readers for a store, and readers
+//!     // never block on a writer nor other readers.
 //!     let reader = env.read().expect("reader");
 //!
-//!     // To retrieve data, call `Reader.get()`, passing it the target store
-//!     // and the key for the value to retrieve.
+//!     // Keys are `AsRef<u8>`, and the return value is `Result<Option<Value>, StoreError>`.
 //!     println!("Get int {:?}", store.get(&reader, "int").unwrap());
 //!     println!("Get uint {:?}", store.get(&reader, "uint").unwrap());
 //!     println!("Get float {:?}", store.get(&reader, "float").unwrap());
@@ -110,7 +107,7 @@
 //!     println!("Get blob {:?}", store.get(&reader, "blob").unwrap());
 //!
 //!     // Retrieving a non-existent value returns `Ok(None)`.
-//!     println!("Get non-existent value {:?}", store.get(&reader, "non-existent"));
+//!     println!("Get non-existent value {:?}", store.get(&reader, "non-existent").unwrap());
 //!
 //!     // A read transaction will automatically close once the reader
 //!     // goes out of scope, so isn't necessary to close it explicitly,
@@ -122,7 +119,6 @@
 //!     let mut writer = env.write().unwrap();
 //!     store.put(&mut writer, "foo", &Value::Str("bar")).unwrap();
 //!     writer.abort();
-//!
 //!     let reader = env.read().expect("reader");
 //!     println!("It should be None! ({:?})", store.get(&reader, "foo").unwrap());
 //! }
@@ -146,21 +142,33 @@
 //!     store.put(&mut writer, "bar", &Value::Str("baz")).unwrap();
 //!     store.delete(&mut writer, "foo").unwrap();
 //!
-//!     // A write transaction also supports reading, the version of the
-//!     // store that it reads includes changes it has made regardless of
+//!     // A write transaction also supports reading, and the version of the
+//!     // store that it reads includes the changes it has made regardless of
 //!     // the commit state of that transaction.
+
 //!     // In the code above, "foo" and "bar" were put into the store,
-//!     // then "foo" was deleted so only "bar" will return a result.
+//!     // then "foo" was deleted so only "bar" will return a result when the
+//!     // database is queried via the writer.
 //!     println!("It should be None! ({:?})", store.get(&writer, "foo").unwrap());
 //!     println!("Get bar ({:?})", store.get(&writer, "bar").unwrap());
+//!
+//!     // But a reader won't see that change until the write transaction
+//!     // is committed.
+//!     {
+//!         let reader = env.read().expect("reader");
+//!         println!("Get foo {:?}", store.get(&reader, "foo").unwrap());
+//!         println!("Get bar {:?}", store.get(&reader, "bar").unwrap());
+//!     }
 //!     writer.commit().unwrap();
-//!     let reader = env.read().expect("reader");
-//!     println!("It should be None! ({:?})", store.get(&reader, "foo").unwrap());
-//!     println!("Get bar {:?}", store.get(&reader, "bar").unwrap());
+//!     {
+//!         let reader = env.read().expect("reader");
+//!         println!("It should be None! ({:?})", store.get(&reader, "foo").unwrap());
+//!         println!("Get bar {:?}", store.get(&reader, "bar").unwrap());
+//!     }
 //!
 //!     // Committing a transaction consumes the writer, preventing you
 //!     // from reusing it by failing at compile time with an error.
-//!     // This line would report error[E0382]: use of moved value: `writer`.
+//!     // This line would report error[E0382]: borrow of moved value: `writer`.
 //!     // store.put(&mut writer, "baz", &Value::Str("buz")).unwrap();
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,8 @@
 //!
 //! {
 //!     // Use a write transaction to mutate the store via a `Writer`.
-//!     // There can be only one writer for a given store; opening a second one
-//!     // will block until the first completes.
+//!     // There can be only one writer for a given environment, so opening
+//!     // a second one will block until the first completes.
 //!     let mut writer = env.write().unwrap();
 //!
 //!     // Keys are `AsRef<[u8]>`, while values are `Value` enum instances.
@@ -92,7 +92,7 @@
 //!
 //! {
 //!     // Use a read transaction to query the store via a `Reader`.
-//!     // There can be unlimited concurrent readers for a store, and readers
+//!     // There can be multiple concurrent readers for a store, and readers
 //!     // never block on a writer nor other readers.
 //!     let reader = env.read().expect("reader");
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //! let env = created_arc.read().unwrap();
 //!
 //! // Then you can use the environment handle to get a handle to a datastore:
-//! let mut store: SingleStore = env.open_single("mydb", StoreOptions::create()).unwrap();
+//! let store: SingleStore = env.open_single("mydb", StoreOptions::create()).unwrap();
 //!
 //! {
 //!     // Use a write transaction to mutate the store via a `Writer`.


### PR DESCRIPTION
@ncloudioj I noticed some more outdated information in the crate docs. This branch corrects it.

Part of the problem is that the docs include an embedded code sample that itself contains embedded comments, and while the code sample itself is tested, the comments embedded inside it aren't, so it's possible for the information in them to become out-of-date.

In addition to updating those comments, I removed method names from them, as those seem like the parts of the doc that are most likely to become out-of-date. I left in data types, however, and added commentary where it seemed appropriate. I also added a bit more code to demonstrate the interaction between an active writer and a reader.

Finally, I updated the description of the E0382 error message you get when you try to reuse a committed writer, as it has changed on the latest stable Rust. And I changed `"héllo, yöu"` to `"Héllo, wörld!"` just for the fun of it.
