### PR TITLE
wrap lmdb-rs transactions in rkv abstraction

### DIFF
--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -13,7 +13,6 @@ use rkv::{
     SingleStore,
     StoreError,
     StoreOptions,
-    Transaction,
     Value,
 };
 use tempfile::Builder;

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -71,5 +71,5 @@ fn populate_store(k: &Rkv, store: SingleStore) -> Result<(), StoreError> {
     ] {
         store.put(&mut writer, country, &city)?;
     }
-    writer.commit().map_err(|e| e.into())
+    writer.commit()
 }

--- a/examples/simple-store.rs
+++ b/examples/simple-store.rs
@@ -11,16 +11,15 @@ use rkv::{
     Manager,
     MultiStore,
     Rkv,
-    RwTransaction,
     StoreOptions,
-    Transaction,
     Value,
+    Writer,
 };
 use tempfile::Builder;
 
 use std::fs;
 
-fn getput<'env, 's>(store: MultiStore, writer: &'env mut RwTransaction, ids: &'s mut Vec<String>) {
+fn getput<'env, 's>(store: MultiStore, writer: &'env mut Writer, ids: &'s mut Vec<String>) {
     let keys = vec!["str1", "str2", "str3"];
     // we convert the writer into a cursor so that we can safely read
     for k in keys.iter() {
@@ -39,7 +38,7 @@ fn getput<'env, 's>(store: MultiStore, writer: &'env mut RwTransaction, ids: &'s
     }
 }
 
-fn delete(store: MultiStore, writer: &mut RwTransaction) {
+fn delete(store: MultiStore, writer: &mut Writer) {
     let keys = vec!["str1", "str2", "str3"];
     let vals = vec!["string uno", "string quatro", "string siete"];
     // we convert the writer into a cursor so that we can safely read

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -1,0 +1,91 @@
+// Copyright 2018-2019 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use lmdb::{
+    Database,
+    RoCursor,
+    RoTransaction,
+    RwTransaction,
+    Transaction,
+    WriteFlags,
+};
+
+use crate::error::StoreError;
+use crate::read_transform;
+use crate::value::Value;
+
+pub struct Reader<'env>(pub RoTransaction<'env>);
+pub struct Writer<'env>(pub RwTransaction<'env>);
+
+pub trait Read {
+    fn get<K: AsRef<[u8]>>(&self, db: Database, k: &K) -> Result<Option<Value>, StoreError>;
+    fn open_ro_cursor(&self, db: Database) -> Result<RoCursor, StoreError>;
+}
+
+impl<'env> Read for Reader<'env> {
+    fn get<K: AsRef<[u8]>>(&self, db: Database, k: &K) -> Result<Option<Value>, StoreError> {
+        let bytes = self.0.get(db, &k);
+        read_transform(bytes)
+    }
+
+    fn open_ro_cursor(&self, db: Database) -> Result<RoCursor, StoreError> {
+        self.0.open_ro_cursor(db).map_err(StoreError::LmdbError)
+    }
+}
+
+impl<'env> Reader<'env> {
+    pub(crate) fn new(txn: RoTransaction) -> Reader {
+        Reader(txn)
+    }
+
+    pub fn abort(self) {
+        self.0.abort();
+    }
+}
+
+impl<'env> Read for Writer<'env> {
+    fn get<K: AsRef<[u8]>>(&self, db: Database, k: &K) -> Result<Option<Value>, StoreError> {
+        let bytes = self.0.get(db, &k);
+        read_transform(bytes)
+    }
+
+    fn open_ro_cursor(&self, db: Database) -> Result<RoCursor, StoreError> {
+        self.0.open_ro_cursor(db).map_err(StoreError::LmdbError)
+    }
+}
+
+impl<'env> Writer<'env> {
+    pub(crate) fn new(txn: RwTransaction) -> Writer {
+        Writer(txn)
+    }
+
+    pub fn commit(self) -> Result<(), StoreError> {
+        self.0.commit().map_err(StoreError::LmdbError)
+    }
+
+    pub fn abort(self) {
+        self.0.abort();
+    }
+
+    pub(crate) fn put<K: AsRef<[u8]>>(
+        &mut self,
+        db: Database,
+        k: &K,
+        v: &Value,
+        flags: WriteFlags,
+    ) -> Result<(), StoreError> {
+        // TODO: don't allocate twice.
+        self.0.put(db, &k, &v.to_bytes()?, flags).map_err(StoreError::LmdbError)
+    }
+
+    pub(crate) fn delete<K: AsRef<[u8]>>(&mut self, db: Database, k: &K, v: Option<&[u8]>) -> Result<(), StoreError> {
+        self.0.del(db, &k, v).map_err(StoreError::LmdbError)
+    }
+}

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -24,12 +24,12 @@ use crate::value::Value;
 pub struct Reader<'env>(pub RoTransaction<'env>);
 pub struct Writer<'env>(pub RwTransaction<'env>);
 
-pub trait Read {
+pub trait Readable {
     fn get<K: AsRef<[u8]>>(&self, db: Database, k: &K) -> Result<Option<Value>, StoreError>;
     fn open_ro_cursor(&self, db: Database) -> Result<RoCursor, StoreError>;
 }
 
-impl<'env> Read for Reader<'env> {
+impl<'env> Readable for Reader<'env> {
     fn get<K: AsRef<[u8]>>(&self, db: Database, k: &K) -> Result<Option<Value>, StoreError> {
         let bytes = self.0.get(db, &k);
         read_transform(bytes)
@@ -50,7 +50,7 @@ impl<'env> Reader<'env> {
     }
 }
 
-impl<'env> Read for Writer<'env> {
+impl<'env> Readable for Writer<'env> {
     fn get<K: AsRef<[u8]>>(&self, db: Database, k: &K) -> Result<Option<Value>, StoreError> {
         let bytes = self.0.get(db, &k);
         read_transform(bytes)

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,11 +3,6 @@ pub mod integermulti;
 pub mod multi;
 pub mod single;
 
-use crate::{
-    error::StoreError,
-    value::OwnedValue,
-    value::Value,
-};
 use lmdb::DatabaseFlags;
 
 #[derive(Default, Debug, Copy, Clone)]
@@ -22,21 +17,5 @@ impl Options {
             create: true,
             flags: DatabaseFlags::empty(),
         }
-    }
-}
-
-fn read_transform(val: Result<&[u8], lmdb::Error>) -> Result<Option<Value>, StoreError> {
-    match val {
-        Ok(bytes) => Value::from_tagged_slice(bytes).map(Some).map_err(StoreError::DataError),
-        Err(lmdb::Error::NotFound) => Ok(None),
-        Err(e) => Err(StoreError::LmdbError(e)),
-    }
-}
-
-fn read_transform_owned(val: Result<&[u8], lmdb::Error>) -> Result<Option<OwnedValue>, StoreError> {
-    match val {
-        Ok(bytes) => Value::from_tagged_slice(bytes).map(|v| Some(OwnedValue::from(&v))).map_err(StoreError::DataError),
-        Err(lmdb::Error::NotFound) => Ok(None),
-        Err(e) => Err(StoreError::LmdbError(e)),
     }
 }

--- a/src/store/integer.rs
+++ b/src/store/integer.rs
@@ -22,7 +22,7 @@ use crate::error::{
 };
 
 use crate::readwrite::{
-    Read,
+    Readable,
     Writer,
 };
 
@@ -94,7 +94,7 @@ where
         }
     }
 
-    pub fn get<'env, T: Read>(&self, reader: &'env T, k: K) -> Result<Option<Value<'env>>, StoreError> {
+    pub fn get<'env, T: Readable>(&self, reader: &'env T, k: K) -> Result<Option<Value<'env>>, StoreError> {
         self.inner.get(reader, Key::new(&k)?)
     }
 

--- a/src/store/integer.rs
+++ b/src/store/integer.rs
@@ -14,15 +14,16 @@ use bincode::serialize;
 
 use serde::Serialize;
 
-use lmdb::{
-    Database,
-    RwTransaction,
-    Transaction,
-};
+use lmdb::Database;
 
 use crate::error::{
     DataError,
     StoreError,
+};
+
+use crate::readwrite::{
+    Read,
+    Writer,
 };
 
 use crate::value::Value;
@@ -93,16 +94,16 @@ where
         }
     }
 
-    pub fn get<'env, T: Transaction>(&self, txn: &'env T, k: K) -> Result<Option<Value<'env>>, StoreError> {
-        self.inner.get(txn, Key::new(&k)?)
+    pub fn get<'env, T: Read>(&self, reader: &'env T, k: K) -> Result<Option<Value<'env>>, StoreError> {
+        self.inner.get(reader, Key::new(&k)?)
     }
 
-    pub fn put(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
-        self.inner.put(txn, Key::new(&k)?, v)
+    pub fn put(&self, writer: &mut Writer, k: K, v: &Value) -> Result<(), StoreError> {
+        self.inner.put(writer, Key::new(&k)?, v)
     }
 
-    pub fn delete(&self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
-        self.inner.delete(txn, Key::new(&k)?)
+    pub fn delete(&self, writer: &mut Writer, k: K) -> Result<(), StoreError> {
+        self.inner.delete(writer, Key::new(&k)?)
     }
 }
 

--- a/src/store/integermulti.rs
+++ b/src/store/integermulti.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 use crate::error::StoreError;
 
 use crate::readwrite::{
-    Read,
+    Readable,
     Writer,
 };
 
@@ -53,11 +53,11 @@ where
         }
     }
 
-    pub fn get<'env, T: Read>(&self, reader: &'env T, k: K) -> Result<Iter<'env>, StoreError> {
+    pub fn get<'env, T: Readable>(&self, reader: &'env T, k: K) -> Result<Iter<'env>, StoreError> {
         self.inner.get(reader, Key::new(&k)?)
     }
 
-    pub fn get_first<'env, T: Read>(&self, reader: &'env T, k: K) -> Result<Option<Value<'env>>, StoreError> {
+    pub fn get_first<'env, T: Readable>(&self, reader: &'env T, k: K) -> Result<Option<Value<'env>>, StoreError> {
         self.inner.get_first(reader, Key::new(&k)?)
     }
 

--- a/src/store/integermulti.rs
+++ b/src/store/integermulti.rs
@@ -10,14 +10,17 @@
 
 use lmdb::{
     Database,
-    RwTransaction,
-    Transaction,
     WriteFlags,
 };
 
 use std::marker::PhantomData;
 
 use crate::error::StoreError;
+
+use crate::readwrite::{
+    Read,
+    Writer,
+};
 
 use crate::value::Value;
 
@@ -50,34 +53,28 @@ where
         }
     }
 
-    pub fn get<'env, T: Transaction>(&self, txn: &'env T, k: K) -> Result<Iter<'env>, StoreError> {
-        self.inner.get(txn, Key::new(&k)?)
+    pub fn get<'env, T: Read>(&self, reader: &'env T, k: K) -> Result<Iter<'env>, StoreError> {
+        self.inner.get(reader, Key::new(&k)?)
     }
 
-    pub fn get_first<'env, T: Transaction>(&self, txn: &'env T, k: K) -> Result<Option<Value<'env>>, StoreError> {
-        self.inner.get_first(txn, Key::new(&k)?)
+    pub fn get_first<'env, T: Read>(&self, reader: &'env T, k: K) -> Result<Option<Value<'env>>, StoreError> {
+        self.inner.get_first(reader, Key::new(&k)?)
     }
 
-    pub fn put(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
-        self.inner.put(txn, Key::new(&k)?, v)
+    pub fn put(&self, writer: &mut Writer, k: K, v: &Value) -> Result<(), StoreError> {
+        self.inner.put(writer, Key::new(&k)?, v)
     }
 
-    pub fn put_with_flags(
-        &self,
-        txn: &mut RwTransaction,
-        k: K,
-        v: &Value,
-        flags: WriteFlags,
-    ) -> Result<(), StoreError> {
-        self.inner.put_with_flags(txn, Key::new(&k)?, v, flags)
+    pub fn put_with_flags(&self, writer: &mut Writer, k: K, v: &Value, flags: WriteFlags) -> Result<(), StoreError> {
+        self.inner.put_with_flags(writer, Key::new(&k)?, v, flags)
     }
 
-    pub fn delete_all(&self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
-        self.inner.delete_all(txn, Key::new(&k)?)
+    pub fn delete_all(&self, writer: &mut Writer, k: K) -> Result<(), StoreError> {
+        self.inner.delete_all(writer, Key::new(&k)?)
     }
 
-    pub fn delete(&self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
-        self.inner.delete(txn, Key::new(&k)?, v)
+    pub fn delete(&self, writer: &mut Writer, k: K, v: &Value) -> Result<(), StoreError> {
+        self.inner.delete(writer, Key::new(&k)?, v)
     }
 }
 

--- a/src/store/multi.rs
+++ b/src/store/multi.rs
@@ -10,7 +10,11 @@
 
 use crate::{
     error::StoreError,
-    store::read_transform,
+    read_transform,
+    readwrite::{
+        Read,
+        Writer,
+    },
     value::Value,
 };
 use lmdb::{
@@ -19,8 +23,6 @@ use lmdb::{
     Iter as LmdbIter,
     //    IterDup as LmdbIterDup,
     RoCursor,
-    RwTransaction,
-    Transaction,
     WriteFlags,
 };
 
@@ -42,8 +44,8 @@ impl MultiStore {
     }
 
     /// Provides a cursor to all of the values for the duplicate entries that match this key
-    pub fn get<T: Transaction, K: AsRef<[u8]>>(self, txn: &T, k: K) -> Result<Iter, StoreError> {
-        let mut cursor = txn.open_ro_cursor(self.db).map_err(StoreError::LmdbError)?;
+    pub fn get<T: Read, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Iter, StoreError> {
+        let mut cursor = reader.open_ro_cursor(self.db)?;
         let iter = cursor.iter_dup_of(k);
         Ok(Iter {
             iter,
@@ -52,36 +54,33 @@ impl MultiStore {
     }
 
     /// Provides the first value that matches this key
-    pub fn get_first<T: Transaction, K: AsRef<[u8]>>(self, txn: &T, k: K) -> Result<Option<Value>, StoreError> {
-        let result = txn.get(self.db, &k);
-        read_transform(result)
+    pub fn get_first<T: Read, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Option<Value>, StoreError> {
+        reader.get(self.db, &k)
     }
 
     /// Insert a value at the specified key.
     /// This put will allow duplicate entries.  If you wish to have duplicate entries
     /// rejected, use the `put_with_flags` function and specify NO_DUP_DATA
-    pub fn put<K: AsRef<[u8]>>(self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
-        let bytes = v.to_bytes()?;
-        txn.put(self.db, &k, &bytes, WriteFlags::empty()).map_err(StoreError::LmdbError)
+    pub fn put<K: AsRef<[u8]>>(self, writer: &mut Writer, k: K, v: &Value) -> Result<(), StoreError> {
+        writer.put(self.db, &k, v, WriteFlags::empty())
     }
 
     pub fn put_with_flags<K: AsRef<[u8]>>(
         self,
-        txn: &mut RwTransaction,
+        writer: &mut Writer,
         k: K,
         v: &Value,
         flags: WriteFlags,
     ) -> Result<(), StoreError> {
-        let bytes = v.to_bytes()?;
-        txn.put(self.db, &k, &bytes, flags).map_err(StoreError::LmdbError)
+        writer.put(self.db, &k, v, flags)
     }
 
-    pub fn delete_all<K: AsRef<[u8]>>(self, txn: &mut RwTransaction, k: K) -> Result<(), StoreError> {
-        txn.del(self.db, &k, None).map_err(StoreError::LmdbError)
+    pub fn delete_all<K: AsRef<[u8]>>(self, writer: &mut Writer, k: K) -> Result<(), StoreError> {
+        writer.delete(self.db, &k, None)
     }
 
-    pub fn delete<K: AsRef<[u8]>>(self, txn: &mut RwTransaction, k: K, v: &Value) -> Result<(), StoreError> {
-        txn.del(self.db, &k, Some(&v.to_bytes()?)).map_err(StoreError::LmdbError)
+    pub fn delete<K: AsRef<[u8]>>(self, writer: &mut Writer, k: K, v: &Value) -> Result<(), StoreError> {
+        writer.delete(self.db, &k, Some(&v.to_bytes()?))
     }
 
     /* TODO - Figure out how to solve the need to have the cursor stick around when

--- a/src/store/multi.rs
+++ b/src/store/multi.rs
@@ -12,7 +12,7 @@ use crate::{
     error::StoreError,
     read_transform,
     readwrite::{
-        Read,
+        Readable,
         Writer,
     },
     value::Value,
@@ -44,7 +44,7 @@ impl MultiStore {
     }
 
     /// Provides a cursor to all of the values for the duplicate entries that match this key
-    pub fn get<T: Read, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Iter, StoreError> {
+    pub fn get<T: Readable, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Iter, StoreError> {
         let mut cursor = reader.open_ro_cursor(self.db)?;
         let iter = cursor.iter_dup_of(k);
         Ok(Iter {
@@ -54,7 +54,7 @@ impl MultiStore {
     }
 
     /// Provides the first value that matches this key
-    pub fn get_first<T: Read, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Option<Value>, StoreError> {
+    pub fn get_first<T: Readable, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Option<Value>, StoreError> {
         reader.get(self.db, &k)
     }
 

--- a/src/store/single.rs
+++ b/src/store/single.rs
@@ -12,7 +12,7 @@ use crate::{
     error::StoreError,
     read_transform,
     readwrite::{
-        Read,
+        Readable,
         Writer,
     },
     value::Value,
@@ -42,7 +42,7 @@ impl SingleStore {
         }
     }
 
-    pub fn get<T: Read, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Option<Value>, StoreError> {
+    pub fn get<T: Readable, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Option<Value>, StoreError> {
         reader.get(self.db, &k)
     }
 
@@ -55,7 +55,7 @@ impl SingleStore {
         writer.delete(self.db, &k, None)
     }
 
-    pub fn iter_start<T: Read>(self, reader: &T) -> Result<Iter, StoreError> {
+    pub fn iter_start<T: Readable>(self, reader: &T) -> Result<Iter, StoreError> {
         let mut cursor = reader.open_ro_cursor(self.db)?;
 
         // We call Cursor.iter() instead of Cursor.iter_start() because
@@ -74,7 +74,7 @@ impl SingleStore {
         })
     }
 
-    pub fn iter_from<T: Read, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Iter, StoreError> {
+    pub fn iter_from<T: Readable, K: AsRef<[u8]>>(self, reader: &T, k: K) -> Result<Iter, StoreError> {
         let mut cursor = reader.open_ro_cursor(self.db)?;
         let iter = cursor.iter_from(k);
         Ok(Iter {

--- a/tests/integer-store.rs
+++ b/tests/integer-store.rs
@@ -12,7 +12,6 @@ use rkv::{
     PrimitiveInt,
     Rkv,
     StoreOptions,
-    Transaction,
     Value,
 };
 use serde_derive::Serialize;

--- a/tests/multi-integer-store.rs
+++ b/tests/multi-integer-store.rs
@@ -12,7 +12,6 @@ use rkv::{
     PrimitiveInt,
     Rkv,
     StoreOptions,
-    Transaction,
     Value,
 };
 use serde_derive::Serialize;


### PR DESCRIPTION
@ncloudioj @rrichardson This branch re-wraps LMDB transactions in a Reader/Writer abstraction to fix #115.

The names aren't important, and I'm happy to use something else (even the same names as LMDB). I just want to achieve consistency in the return values of rkv methods, so they don't return sometimes `Result<_, StoreError>` and other times `Result<_, lmdb::Error>`.

In the process, I also added testing of `MultiStore.get_first()` and `MultiStore.delete_all()` to confirm that they work as expected.

Let me know what you think.
