### PR TITLE
update patch version to 0.9.1 for lmdb-rkv 0.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkv"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Richard Newman <rnewman@twinql.com>", "Nan Jiang <najiang@mozilla.com>", "Myk Melez <myk@mykzilla.org>"]
 description = "a simple, humane, typed Rust interface to LMDB"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ backtrace = ["failure/backtrace", "failure/std"]
 arrayref = "0.3"
 bincode = "1.0"
 lazy_static = "1.0.2"
-lmdb-rkv = "0.11.1"
+lmdb-rkv = "0.11.2"
 ordered-float = "1.0"
 uuid = "0.7"
 serde = "1.0"


### PR DESCRIPTION
Update the patch version for rkv to 0.9.1 and its lmdb-rkv dependency version to 0.11.2 in preparation for publishing rkv 0.9.1.