### PR TITLE
derive Clone for OwnedValue

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -96,7 +96,7 @@ pub enum Value<'s> {
     Blob(&'s [u8]),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OwnedValue {
     Bool(bool),
     U64(u64),


### PR DESCRIPTION
This has been sitting in my local clone for a while, and I don't remember why I never requested a pull for it. It enables some downstream refactoring in the kvstore consumer (which currently implements its own _OwnedValue_ type): https://github.com/mykmelez/gecko/compare/central-update-rkv...use-rkv-owned-value

@rnewman I'm curious if it was intentional to make `Value::F64` store an `OrderedFloat<f64>` but `OwnedValue::F64` store a primitive `f64`. An earlier version of this branch made `OwnedValue::F64` also store an `OrderedFloat<f64>`, so that it could derive `Eq`.

I've undone that change in the current version of this branch, as it didn't turn out to be necessary to support the downstream use case; but I'm curious for your thoughts on the relative merits of retaining the current type as `OwnedValue::F64(f64)` vs. converting it to `OwnedValue::F64(OrderedFloat<f64>)`.
