### PR TITLE
implement From<OwnedValue> for Value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,16 @@ matrix:
     - rust: nightly
   fast_finish: true
 before_script:
-  - rustup toolchain install nightly
-  - rustup component add rustfmt-preview --toolchain nightly
+  # We install a known-to-have-rustfmt version of the nightly toolchain
+  # in order to run the nightly version of rustfmt, which supports rules
+  # that we depend upon.
+  - rustup toolchain install nightly-2019-02-07
+  - rustup component add rustfmt --toolchain nightly-2019-02-07
   - command -v rustfmt || cargo install --force rustfmt-nightly
   # install clippy via rustup, use the github source as a fallback
   - rustup component add clippy || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
 script:
-  - cargo +nightly fmt --all -- --check
+  - cargo +nightly-2019-02-07 fmt --all -- --check
   # check all the targets (source code, tests, non-default crate features), and stop the build upon any warning
   - cargo clippy --all-targets --all-features -- -D warnings
   - cargo build --verbose

--- a/src/value.rs
+++ b/src/value.rs
@@ -168,15 +168,15 @@ impl<'s> Value<'s> {
 
     pub fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
         match self {
-            Value::Bool(ref v) => serialize(&(Type::Bool.to_tag(), *v)),
-            Value::U64(ref v) => serialize(&(Type::U64.to_tag(), *v)),
-            Value::I64(ref v) => serialize(&(Type::I64.to_tag(), *v)),
-            Value::F64(ref v) => serialize(&(Type::F64.to_tag(), v.0)),
-            Value::Instant(ref v) => serialize(&(Type::Instant.to_tag(), *v)),
-            Value::Str(ref v) => serialize(&(Type::Str.to_tag(), v)),
-            Value::Json(ref v) => serialize(&(Type::Json.to_tag(), v)),
-            Value::Blob(ref v) => serialize(&(Type::Blob.to_tag(), v)),
-            Value::Uuid(ref v) => {
+            Value::Bool(v) => serialize(&(Type::Bool.to_tag(), *v)),
+            Value::U64(v) => serialize(&(Type::U64.to_tag(), *v)),
+            Value::I64(v) => serialize(&(Type::I64.to_tag(), *v)),
+            Value::F64(v) => serialize(&(Type::F64.to_tag(), v.0)),
+            Value::Instant(v) => serialize(&(Type::Instant.to_tag(), *v)),
+            Value::Str(v) => serialize(&(Type::Str.to_tag(), v)),
+            Value::Json(v) => serialize(&(Type::Json.to_tag(), v)),
+            Value::Blob(v) => serialize(&(Type::Blob.to_tag(), v)),
+            Value::Uuid(v) => {
                 // Processed above to avoid verbose duplication of error transforms.
                 serialize(&(Type::Uuid.to_tag(), v))
             },
@@ -188,15 +188,31 @@ impl<'s> Value<'s> {
 impl<'s> From<&'s Value<'s>> for OwnedValue {
     fn from(value: &Value) -> OwnedValue {
         match value {
-            Value::Bool(ref v) => OwnedValue::Bool(*v),
-            Value::U64(ref v) => OwnedValue::U64(*v),
-            Value::I64(ref v) => OwnedValue::I64(*v),
-            Value::F64(ref v) => OwnedValue::F64(**v),
-            Value::Instant(ref v) => OwnedValue::Instant(*v),
-            Value::Uuid(ref v) => OwnedValue::Uuid(Uuid::from_bytes(**v)),
-            Value::Str(ref v) => OwnedValue::Str(v.to_string()),
-            Value::Json(ref v) => OwnedValue::Json(v.to_string()),
-            Value::Blob(ref v) => OwnedValue::Blob(v.to_vec()),
+            Value::Bool(v) => OwnedValue::Bool(*v),
+            Value::U64(v) => OwnedValue::U64(*v),
+            Value::I64(v) => OwnedValue::I64(*v),
+            Value::F64(v) => OwnedValue::F64(**v),
+            Value::Instant(v) => OwnedValue::Instant(*v),
+            Value::Uuid(v) => OwnedValue::Uuid(Uuid::from_bytes(**v)),
+            Value::Str(v) => OwnedValue::Str(v.to_string()),
+            Value::Json(v) => OwnedValue::Json(v.to_string()),
+            Value::Blob(v) => OwnedValue::Blob(v.to_vec()),
+        }
+    }
+}
+
+impl<'s> From<&'s OwnedValue> for Value<'s> {
+    fn from(value: &OwnedValue) -> Value {
+        match value {
+            OwnedValue::Bool(v) => Value::Bool(*v),
+            OwnedValue::U64(v) => Value::U64(*v),
+            OwnedValue::I64(v) => Value::I64(*v),
+            OwnedValue::F64(v) => Value::F64(OrderedFloat::from(*v)),
+            OwnedValue::Instant(v) => Value::Instant(*v),
+            OwnedValue::Uuid(v) => Value::Uuid(v.as_bytes()),
+            OwnedValue::Str(v) => Value::Str(v),
+            OwnedValue::Json(v) => Value::Json(v),
+            OwnedValue::Blob(v) => Value::Blob(v),
         }
     }
 }


### PR DESCRIPTION
Over in https://phabricator.services.mozilla.com/D19436#inline-106713, @mystor wondered why rkv doesn't provide a conversion from `OwnedValue` to `Value`, which is indeed a missing piece in rkv's API that requires downstream consumers like kvstore to implement the conversion themselves.

Here's an implementation that enables downstream consumers like kvstore to avoid implementing it themselves. Along the way, I removed unnecessary `ref` annotations now that rkv specifies `edition = "2018"` and thus [infers the binding mode for match bindings](https://rust-lang-nursery.github.io/edition-guide/rust-2018/ownership-and-lifetimes/default-match-bindings.html).
