### PR TITLE
Implement clear for stores

### DIFF
--- a/examples/simple-store.rs
+++ b/examples/simple-store.rs
@@ -153,6 +153,20 @@ fn main() {
         // store.put(&mut writer, "baz", &Value::Str("buz")).unwrap();
     }
 
+    println!("Clearing store...");
+    {
+        // Clearing a store deletes all the entries in that store
+        let mut writer = k.write().unwrap();
+        store.put(&mut writer, "foo", &Value::Str("bar")).unwrap();
+        store.put(&mut writer, "bar", &Value::Str("baz")).unwrap();
+        store.clear(&mut writer).unwrap();
+        writer.commit().unwrap();
+
+        let reader = k.read().expect("reader");
+        println!("It should be None! ({:?})", store.get(&reader, "foo").unwrap());
+        println!("It should be None! ({:?})", store.get(&reader, "bar").unwrap());
+    }
+
     println!("Write and read on multiple stores...");
     {
         let another_store = k.open_single("another_store", StoreOptions::create()).unwrap();

--- a/src/env.rs
+++ b/src/env.rs
@@ -194,12 +194,12 @@ impl Rkv {
     /// Otherwise if the environment has the `NO_SYNC` flag set the flushes will be omitted,
     /// and with `MAP_ASYNC` they will be asynchronous.
     pub fn sync(&self, force: bool) -> Result<(), StoreError> {
-        self.env.sync(force).map_err(|e| e.into())
+        self.env.sync(force).map_err(Into::into)
     }
 
     /// Retrieves statistics about this environment.
     pub fn stat(&self) -> Result<Stat, StoreError> {
-        self.env.stat().map_err(|e| e.into())
+        self.env.stat().map_err(Into::into)
     }
 }
 
@@ -592,7 +592,7 @@ mod tests {
         // Open the same store for read while the reader is in progress will panic
         let store: Result<SingleStore, StoreError> = k.open_single("sk", StoreOptions::default());
         match store {
-            Err(StoreError::OpenAttemptedDuringTransaction(_thread_id)) => assert!(true),
+            Err(StoreError::OpenAttemptedDuringTransaction(_thread_id)) => (),
             _ => panic!("should panic"),
         }
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -455,6 +455,35 @@ mod tests {
     }
 
     #[test]
+    fn test_single_store_clear() {
+        let root = Builder::new().prefix("test_single_store_clear").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+        let k = Rkv::new(root.path()).expect("new succeeded");
+
+        let sk: SingleStore = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        {
+            let mut writer = k.write().expect("writer");
+            sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+            sk.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+            sk.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            sk.clear(&mut writer).expect("cleared");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let r = k.read().unwrap();
+            let iter = sk.iter_start(&r).expect("iter");
+            assert_eq!(iter.count(), 0);
+        }
+    }
+
+    #[test]
     fn test_multi_put_get_del() {
         let root = Builder::new().prefix("test_multi_put_get_del").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
@@ -488,6 +517,39 @@ mod tests {
         multistore.delete_all(&mut writer, "str3").unwrap();
         assert_eq!(multistore.get_first(&writer, "str3").unwrap(), None);
         writer.commit().unwrap();
+    }
+
+    #[test]
+    fn test_multiple_store_clear() {
+        let root = Builder::new().prefix("test_multiple_store_clear").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+        let k = Rkv::new(root.path()).expect("new succeeded");
+
+        let multistore = k.open_multi("multistore", StoreOptions::create()).expect("opened");
+
+        {
+            let mut writer = k.write().expect("writer");
+            multistore.put(&mut writer, "str1", &Value::Str("str1 foo")).unwrap();
+            multistore.put(&mut writer, "str1", &Value::Str("str1 bar")).unwrap();
+            multistore.put(&mut writer, "str2", &Value::Str("str2 foo")).unwrap();
+            multistore.put(&mut writer, "str2", &Value::Str("str2 bar")).unwrap();
+            multistore.put(&mut writer, "str3", &Value::Str("str3 foo")).unwrap();
+            multistore.put(&mut writer, "str3", &Value::Str("str3 bar")).unwrap();
+            writer.commit().expect("committed");
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            multistore.clear(&mut writer).expect("cleared");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let r = k.read().unwrap();
+            assert_eq!(multistore.get_first(&r, "str1").expect("read"), None);
+            assert_eq!(multistore.get_first(&r, "str2").expect("read"), None);
+            assert_eq!(multistore.get_first(&r, "str3").expect("read"), None);
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,30 @@
 //!     // This line would report error[E0382]: borrow of moved value: `writer`.
 //!     // store.put(&mut writer, "baz", &Value::Str("buz")).unwrap();
 //! }
+//!
+//! {
+//!     // Clearing all the entries in the store with a write transaction.
+//!     {
+//!         let mut writer = env.write().unwrap();
+//!         store.put(&mut writer, "foo", &Value::Str("bar")).unwrap();
+//!         store.put(&mut writer, "bar", &Value::Str("baz")).unwrap();
+//!         writer.commit().unwrap();
+//!     }
+//!
+//!     {
+//!         let mut writer = env.write().unwrap();
+//!         store.clear(&mut writer).unwrap();
+//!         writer.commit().unwrap();
+//!     }
+//!
+//!     {
+//!         let reader = env.read().expect("reader");
+//!         println!("It should be None! ({:?})", store.get(&reader, "foo").unwrap());
+//!         println!("It should be None! ({:?})", store.get(&reader, "bar").unwrap());
+//!     }
+//!
+//! }
+//!
 //! ```
 
 #![allow(dead_code)]

--- a/src/readwrite.rs
+++ b/src/readwrite.rs
@@ -88,4 +88,8 @@ impl<'env> Writer<'env> {
     pub(crate) fn delete<K: AsRef<[u8]>>(&mut self, db: Database, k: &K, v: Option<&[u8]>) -> Result<(), StoreError> {
         self.0.del(db, &k, v).map_err(StoreError::LmdbError)
     }
+
+    pub(crate) fn clear(&mut self, db: Database) -> Result<(), StoreError> {
+        self.0.clear_db(db).map_err(StoreError::LmdbError)
+    }
 }

--- a/src/store/integer.rs
+++ b/src/store/integer.rs
@@ -44,7 +44,7 @@ where
 {
     fn to_bytes(&self) -> Result<Vec<u8>, DataError> {
         serialize(self) // TODO: limited key length.
-            .map_err(|e| e.into())
+            .map_err(Into::into)
     }
 }
 

--- a/src/store/integer.rs
+++ b/src/store/integer.rs
@@ -105,6 +105,10 @@ where
     pub fn delete(&self, writer: &mut Writer, k: K) -> Result<(), StoreError> {
         self.inner.delete(writer, Key::new(&k)?)
     }
+
+    pub fn clear(&self, writer: &mut Writer) -> Result<(), StoreError> {
+        self.inner.clear(writer)
+    }
 }
 
 #[cfg(test)]
@@ -137,5 +141,32 @@ mod tests {
 
         test_integer_keys!(u32, std::u32::MIN);
         test_integer_keys!(u32, std::u32::MAX);
+    }
+
+    #[test]
+    fn test_clear() {
+        let root = Builder::new().prefix("test_integer_clear").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+        let k = Rkv::new(root.path()).expect("new succeeded");
+        let s = k.open_integer("s", StoreOptions::create()).expect("open");
+
+        {
+            let mut writer = k.write().expect("writer");
+            s.put(&mut writer, 1, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 2, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 3, &Value::Str("hello!")).expect("write");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            s.clear(&mut writer).expect("cleared");
+            writer.commit().expect("committed");
+
+            let reader = k.read().expect("reader");
+            assert_eq!(s.get(&reader, 1).expect("read"), None);
+            assert_eq!(s.get(&reader, 2).expect("read"), None);
+            assert_eq!(s.get(&reader, 3).expect("read"), None);
+        }
     }
 }

--- a/src/store/integermulti.rs
+++ b/src/store/integermulti.rs
@@ -76,6 +76,10 @@ where
     pub fn delete(&self, writer: &mut Writer, k: K, v: &Value) -> Result<(), StoreError> {
         self.inner.delete(writer, Key::new(&k)?, v)
     }
+
+    pub fn clear(&self, writer: &mut Writer) -> Result<(), StoreError> {
+        self.inner.clear(writer)
+    }
 }
 
 #[cfg(test)]
@@ -110,5 +114,31 @@ mod tests {
 
         test_integer_keys!(u32, std::u32::MIN);
         test_integer_keys!(u32, std::u32::MAX);
+    }
+
+    #[test]
+    fn test_clear() {
+        let root = Builder::new().prefix("test_multi_integer_clear").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+        let k = Rkv::new(root.path()).expect("new succeeded");
+        let s = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+
+        {
+            let mut writer = k.write().expect("writer");
+            s.put(&mut writer, 1, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 1, &Value::Str("hello1!")).expect("write");
+            s.put(&mut writer, 2, &Value::Str("hello!")).expect("write");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            s.clear(&mut writer).expect("cleared");
+            writer.commit().expect("committed");
+
+            let reader = k.read().expect("reader");
+            assert_eq!(s.get_first(&reader, 1).expect("read"), None);
+            assert_eq!(s.get_first(&reader, 2).expect("read"), None);
+        }
     }
 }

--- a/src/store/multi.rs
+++ b/src/store/multi.rs
@@ -105,6 +105,10 @@ impl MultiStore {
         })
     }
     */
+
+    pub fn clear(self, writer: &mut Writer) -> Result<(), StoreError> {
+        writer.clear(self.db)
+    }
 }
 
 /*

--- a/src/store/single.rs
+++ b/src/store/single.rs
@@ -82,6 +82,10 @@ impl SingleStore {
             cursor,
         })
     }
+
+    pub fn clear(self, writer: &mut Writer) -> Result<(), StoreError> {
+        writer.clear(self.db)
+    }
 }
 
 impl<'env> Iterator for Iter<'env> {


### PR DESCRIPTION
This fixes the "clear" part of #126.

With this addition, we can then implement the bulk insert&delete for kvstore.