### PR TITLE
manage immutable Arc<Rkv> rather than interiorly mutable Arc<RwLock<Rkv>>

### DIFF
--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -25,8 +25,7 @@ fn main() {
     fs::create_dir_all(root.path()).unwrap();
     let p = root.path();
 
-    let created_arc = Manager::singleton().write().unwrap().get_or_create(p, Rkv::new).unwrap();
-    let k = created_arc.read().unwrap();
+    let k = Manager::singleton().write().unwrap().get_or_create(p, Rkv::new).unwrap();
     let store = k.open_single("store", StoreOptions::create()).unwrap();
 
     populate_store(&k, store).unwrap();

--- a/examples/simple-store.rs
+++ b/examples/simple-store.rs
@@ -53,8 +53,7 @@ fn main() {
     let p = root.path();
 
     // The manager enforces that each process opens the same lmdb environment at most once
-    let created_arc = Manager::singleton().write().unwrap().get_or_create(p, Rkv::new).unwrap();
-    let k = created_arc.read().unwrap();
+    let k = Manager::singleton().write().unwrap().get_or_create(p, Rkv::new).unwrap();
 
     // Creates a store called "store"
     let store = k.open_single("store", StoreOptions::create()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,7 @@
 //! // at most once by caching a handle to each environment that it opens.
 //! // Use it to retrieve the handle to an opened environment—or create one
 //! // if it hasn't already been opened:
-//! let created_arc = Manager::singleton().write().unwrap().get_or_create(path, Rkv::new).unwrap();
-//! let env = created_arc.read().unwrap();
+//! let env = Manager::singleton().write().unwrap().get_or_create(path, Rkv::new).unwrap();
 //!
 //! // Then you can use the environment handle to get a handle to a datastore:
 //! let store: SingleStore = env.open_single("mydb", StoreOptions::create()).unwrap();

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -58,7 +58,7 @@ where
 }
 
 pub struct Manager {
-    environments: BTreeMap<PathBuf, Arc<RwLock<Rkv>>>,
+    environments: BTreeMap<PathBuf, Arc<Rkv>>,
 }
 
 impl Manager {
@@ -73,7 +73,7 @@ impl Manager {
     }
 
     /// Return the open env at `path`, returning `None` if it has not already been opened.
-    pub fn get<'p, P>(&self, path: P) -> Result<Option<Arc<RwLock<Rkv>>>, ::std::io::Error>
+    pub fn get<'p, P>(&self, path: P) -> Result<Option<Arc<Rkv>>, ::std::io::Error>
     where
         P: Into<&'p Path>,
     {
@@ -82,7 +82,7 @@ impl Manager {
     }
 
     /// Return the open env at `path`, or create it by calling `f`.
-    pub fn get_or_create<'p, F, P>(&mut self, path: P, f: F) -> Result<Arc<RwLock<Rkv>>, StoreError>
+    pub fn get_or_create<'p, F, P>(&mut self, path: P, f: F) -> Result<Arc<Rkv>, StoreError>
     where
         F: FnOnce(&Path) -> Result<Rkv, StoreError>,
         P: Into<&'p Path>,
@@ -91,7 +91,7 @@ impl Manager {
         Ok(match self.environments.entry(canonical) {
             Entry::Occupied(e) => e.get().clone(),
             Entry::Vacant(e) => {
-                let k = Arc::new(RwLock::new(f(e.key().as_path())?));
+                let k = Arc::new(f(e.key().as_path())?);
                 e.insert(k).clone()
             },
         })
@@ -104,7 +104,7 @@ impl Manager {
         path: P,
         capacity: c_uint,
         f: F,
-    ) -> Result<Arc<RwLock<Rkv>>, StoreError>
+    ) -> Result<Arc<Rkv>, StoreError>
     where
         F: FnOnce(&Path, c_uint) -> Result<Rkv, StoreError>,
         P: Into<&'p Path>,
@@ -113,7 +113,7 @@ impl Manager {
         Ok(match self.environments.entry(canonical) {
             Entry::Occupied(e) => e.get().clone(),
             Entry::Vacant(e) => {
-                let k = Arc::new(RwLock::new(f(e.key().as_path(), capacity)?));
+                let k = Arc::new(f(e.key().as_path(), capacity)?);
                 e.insert(k).clone()
             },
         })


### PR DESCRIPTION
Manager currently manages `Arc<RwLock<Rkv>>` instances, which enables interior mutability of the Rkv instances. That can result in surprising behavior when fetching a mutated Rkv from the Manager. It also requires consumers to acquire a (read, at least) lock to use a managed Rkv, even though all of its methods take an immutable reference to self (`&self`).

This branch removes the RwLock from managed Rkv instances, such that Manager returns `Arc<Rkv>`, which is immutable, cannot result in surprising behavior when fetching an Rkv from the Manager, and doesn't need to be locked.

Note that this is a breaking change that will require an incompatible version bump (currently a minor version bump, as we're still pre-1.0).

It's also worth considering whether there is some reason to keep this lock, even though it isn't currently necessary. For example, if we want consumers to be able to close an environment in the future using [mdb_env_close()](http://www.lmdb.tech/doc/group__mdb.html#ga4366c43ada8874588b6a62fbda2d1e95), which can only be called by a single thread, then we'll need a way to lock the Rkv instance.

In that case, I think we can implement internal locking in Rkv of its `env` field, making it hold an `RwLock<MDB_env>` and lock it for writing before closing the environment.

@ncloudioj What do you think?
