### PR TITLE
update version for 0.9.5 release (fixes #140)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rkv"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Richard Newman <rnewman@twinql.com>", "Nan Jiang <najiang@mozilla.com>", "Myk Melez <myk@mykzilla.org>"]
 description = "a simple, humane, typed Rust interface to LMDB"
 license = "Apache-2.0"


### PR DESCRIPTION
Once this is merged, I'll publish the crate to crates.io, and that'll fix #140.