### PR TITLE
exposing Readable trait to consumers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,7 @@ pub use lmdb::{
 pub use self::readwrite::{
     Reader,
     Writer,
+    Readable,
 };
 pub use self::store::integer::{
     IntegerStore,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,9 +224,9 @@ pub use lmdb::{
 };
 
 pub use self::readwrite::{
+    Readable,
     Reader,
     Writer,
-    Readable,
 };
 pub use self::store::integer::{
     IntegerStore,


### PR DESCRIPTION
Make the Readable trait public, so that users can use Reader and Writer transactions interchangeably for read operations.  