### PR TITLE
test exceeding LMDB's key size limit

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -397,6 +397,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "wrote: LmdbError(BadValSize)")]
     fn test_exceed_key_size_limit() {
         let root = Builder::new().prefix("test_exceed_key_size_limit").tempdir().expect("tempdir");
         println!("Root path: {:?}", root.path());

--- a/src/env.rs
+++ b/src/env.rs
@@ -397,6 +397,21 @@ mod tests {
     }
 
     #[test]
+    fn test_exceed_key_size_limit() {
+        let root = Builder::new().prefix("test_exceed_key_size_limit").tempdir().expect("tempdir");
+        println!("Root path: {:?}", root.path());
+        fs::create_dir_all(root.path()).expect("dir created");
+        assert!(root.path().is_dir());
+
+        let k = Rkv::new(root.path()).expect("new succeeded");
+        let sk: SingleStore = k.open_single("test", StoreOptions::create()).expect("opened");
+
+        let key = "k".repeat(512);
+        let mut writer = k.write().expect("writer");
+        sk.put(&mut writer, key, &Value::Str("val")).expect("wrote");
+    }
+
+    #[test]
     fn test_increase_map_size() {
         let root = Builder::new().prefix("test_open_with_map_size").tempdir().expect("tempdir");
         println!("Root path: {:?}", root.path());


### PR DESCRIPTION
@victorporof This was my attempt to reproduce the mdb_cursor_put crash via a too-long key. Long story short, I didn't reproduce it; LMDB just returns an error. But I wonder if some different key size might do so, or if there's something else about the way that LMDB is compiled into Firefox that causes it to crash instead of returning an error.

(Regardless, I guess it's useful to have this test, although ideally rkv would prevent its consumers from using an overlong key to begin with.)
