### PR TITLE
Safe mode arena allocation for databases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/tests/envs/*"]
 [features]
 default = ["with-safe-mode"]
 backtrace = ["failure/backtrace", "failure/std"]
-with-safe-mode = ["log", "uuid/v4", "uuid/serde", "serde/derive", "serde/rc"]
+with-safe-mode = ["id-arena", "log", "serde/derive"]
 with-asan = ["lmdb-rkv/with-asan"]
 with-fuzzer = ["lmdb-rkv/with-fuzzer"]
 with-fuzzer-no-link = ["lmdb-rkv/with-fuzzer-no-link"]
@@ -26,6 +26,7 @@ arrayref = "0.3"
 bincode = "1.0"
 bitflags = "1"
 byteorder = "1"
+id-arena = { version = "2.2", optional = true }
 lazy_static = "1.0"
 lmdb-rkv = "0.12.3"
 log = { version = "0.4", optional = true }

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -35,7 +35,7 @@ fn main() {
     let k = created_arc.read().unwrap();
     let store = k.open_single("store", StoreOptions::create()).unwrap();
 
-    populate_store(&k, &store).unwrap();
+    populate_store(&k, store).unwrap();
 
     let reader = k.read().unwrap();
 
@@ -64,7 +64,7 @@ fn main() {
     }
 }
 
-fn populate_store(k: &Rkv<LmdbEnvironment>, store: &SingleStore<LmdbDatabase>) -> Result<(), StoreError> {
+fn populate_store(k: &Rkv<LmdbEnvironment>, store: SingleStore<LmdbDatabase>) -> Result<(), StoreError> {
     let mut writer = k.write()?;
     for (country, city) in vec![
         ("Canada", Value::Str("Ottawa")),

--- a/examples/simple-store.rs
+++ b/examples/simple-store.rs
@@ -27,7 +27,7 @@ use rkv::{
 type MultiStore = rkv::MultiStore<LmdbDatabase>;
 type Writer<'env> = rkv::Writer<LmdbRwTransaction<'env>>;
 
-fn getput<'env, 's>(store: &MultiStore, writer: &'env mut Writer, ids: &'s mut Vec<String>) {
+fn getput<'env, 's>(store: MultiStore, writer: &'env mut Writer, ids: &'s mut Vec<String>) {
     let keys = vec!["str1", "str2", "str3"];
     // we convert the writer into a cursor so that we can safely read
     for k in keys.iter() {
@@ -46,7 +46,7 @@ fn getput<'env, 's>(store: &MultiStore, writer: &'env mut Writer, ids: &'s mut V
     }
 }
 
-fn delete(store: &MultiStore, writer: &mut Writer) {
+fn delete(store: MultiStore, writer: &mut Writer) {
     let keys = vec!["str1", "str2", "str3"];
     let vals = vec!["string uno", "string quatro", "string siete"];
     // we convert the writer into a cursor so that we can safely read
@@ -96,10 +96,10 @@ fn main() {
         multistore.put(&mut writer, "str3", &Value::Str("string siete")).unwrap();
         multistore.put(&mut writer, "str3", &Value::Str("string ocho")).unwrap();
         multistore.put(&mut writer, "str3", &Value::Str("string nueve")).unwrap();
-        getput(&multistore, &mut writer, &mut ids);
+        getput(multistore, &mut writer, &mut ids);
         writer.commit().unwrap();
         let mut writer = k.write().unwrap();
-        delete(&multistore, &mut writer);
+        delete(multistore, &mut writer);
         writer.commit().unwrap();
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -24,7 +24,7 @@ pub use impl_lmdb::RoCursorImpl as LmdbRoCursor;
 pub use impl_lmdb::RoTransactionImpl as LmdbRoTransaction;
 pub use impl_lmdb::RwTransactionImpl as LmdbRwTransaction;
 
-pub use impl_safe::DatabaseImpl as SafeModeDatabase;
+pub use impl_safe::DatabaseId as SafeModeDatabase;
 pub use impl_safe::EnvironmentBuilderImpl as SafeMode;
 pub use impl_safe::EnvironmentImpl as SafeModeEnvironment;
 pub use impl_safe::ErrorImpl as SafeModeError;

--- a/src/backend/impl_lmdb/database.rs
+++ b/src/backend/impl_lmdb/database.rs
@@ -10,7 +10,7 @@
 
 use crate::backend::traits::BackendDatabase;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct DatabaseImpl(pub(crate) lmdb::Database);
 
 impl BackendDatabase for DatabaseImpl {}

--- a/src/backend/impl_safe.rs
+++ b/src/backend/impl_safe.rs
@@ -22,7 +22,7 @@ pub use cursor::{
     RoCursorImpl,
     RwCursorImpl,
 };
-pub use database::DatabaseImpl;
+pub use database::DatabaseId;
 pub use environment::{
     EnvironmentBuilderImpl,
     EnvironmentImpl,

--- a/src/backend/impl_safe/error.rs
+++ b/src/backend/impl_safe/error.rs
@@ -22,7 +22,6 @@ pub enum ErrorImpl {
     DbPoisonError,
     DbNotFoundError,
     DbIsForeignError,
-    TxnPoisonError,
     IoError(io::Error),
     BincodeError(BincodeError),
 }
@@ -36,7 +35,6 @@ impl fmt::Display for ErrorImpl {
             ErrorImpl::DbPoisonError => write!(fmt, "DbPoisonError (safe mode)"),
             ErrorImpl::DbNotFoundError => write!(fmt, "DbNotFoundError (safe mode)"),
             ErrorImpl::DbIsForeignError => write!(fmt, "DbIsForeignError (safe mode)"),
-            ErrorImpl::TxnPoisonError => write!(fmt, "TxnPoisonError (safe mode)"),
             ErrorImpl::IoError(e) => e.fmt(fmt),
             ErrorImpl::BincodeError(e) => e.fmt(fmt),
         }

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -23,7 +23,7 @@ use crate::error::StoreError;
 
 pub trait BackendError: Debug + Display + Into<StoreError> {}
 
-pub trait BackendDatabase: Debug {}
+pub trait BackendDatabase: Debug + Eq + PartialEq + Copy + Clone {}
 
 pub trait BackendFlags: Debug + Eq + PartialEq + Copy + Clone + Default {
     fn empty() -> Self;

--- a/src/store/integer.rs
+++ b/src/store/integer.rs
@@ -216,6 +216,36 @@ mod tests {
             assert_eq!(s.get(&reader, 3).expect("read"), None);
         }
     }
+
+    #[test]
+    fn test_persist() {
+        let root = Builder::new().prefix("test_integer_persist").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        {
+            let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
+            let s = k.open_integer("s", StoreOptions::create()).expect("open");
+
+            let mut writer = k.write().expect("writer");
+            s.put(&mut writer, 1, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 2, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 3, &Value::Str("hello!")).expect("write");
+            assert_eq!(s.get(&writer, 1).expect("read"), Some(Value::Str("hello!")));
+            assert_eq!(s.get(&writer, 2).expect("read"), Some(Value::Str("hello!")));
+            assert_eq!(s.get(&writer, 3).expect("read"), Some(Value::Str("hello!")));
+            writer.commit().expect("committed");
+        }
+
+        {
+            let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
+            let s = k.open_integer("s", StoreOptions::create()).expect("open");
+
+            let reader = k.read().expect("reader");
+            assert_eq!(s.get(&reader, 1).expect("read"), Some(Value::Str("hello!")));
+            assert_eq!(s.get(&reader, 2).expect("read"), Some(Value::Str("hello!")));
+            assert_eq!(s.get(&reader, 3).expect("read"), Some(Value::Str("hello!")));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -357,6 +387,36 @@ mod tests_safe {
 
             let reader = k.read().expect("reader");
             assert_eq!(s.get(&reader, 3).expect("read"), None);
+        }
+    }
+
+    #[test]
+    fn test_persist() {
+        let root = Builder::new().prefix("test_integer_persist").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        {
+            let k = Rkv::new::<backend::SafeMode>(root.path()).expect("new succeeded");
+            let s = k.open_integer("s", StoreOptions::create()).expect("open");
+
+            let mut writer = k.write().expect("writer");
+            s.put(&mut writer, 1, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 2, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 3, &Value::Str("hello!")).expect("write");
+            assert_eq!(s.get(&writer, 1).expect("read"), Some(Value::Str("hello!")));
+            assert_eq!(s.get(&writer, 2).expect("read"), Some(Value::Str("hello!")));
+            assert_eq!(s.get(&writer, 3).expect("read"), Some(Value::Str("hello!")));
+            writer.commit().expect("committed");
+        }
+
+        {
+            let k = Rkv::new::<backend::SafeMode>(root.path()).expect("new succeeded");
+            let s = k.open_integer("s", StoreOptions::create()).expect("open");
+
+            let reader = k.read().expect("reader");
+            assert_eq!(s.get(&reader, 1).expect("read"), Some(Value::Str("hello!")));
+            assert_eq!(s.get(&reader, 2).expect("read"), Some(Value::Str("hello!")));
+            assert_eq!(s.get(&reader, 3).expect("read"), Some(Value::Str("hello!")));
         }
     }
 }

--- a/src/store/integer.rs
+++ b/src/store/integer.rs
@@ -28,6 +28,7 @@ use crate::value::Value;
 
 type EmptyResult = Result<(), StoreError>;
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct IntegerStore<D, K> {
     inner: SingleStore<D>,
     phantom: PhantomData<K>,

--- a/src/store/integermulti.rs
+++ b/src/store/integermulti.rs
@@ -33,6 +33,7 @@ use crate::value::Value;
 
 type EmptyResult = Result<(), StoreError>;
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct MultiIntegerStore<D, K> {
     inner: MultiStore<D>,
     phantom: PhantomData<K>,

--- a/src/store/integermulti.rs
+++ b/src/store/integermulti.rs
@@ -283,6 +283,40 @@ mod tests {
             assert!(iter.next().is_none());
         }
     }
+
+    #[test]
+    fn test_persist() {
+        let root = Builder::new().prefix("test_multi_integer_persist").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        {
+            let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
+            let s = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+
+            let mut writer = k.write().expect("writer");
+            s.put(&mut writer, 1, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 1, &Value::Str("hello1!")).expect("write");
+            s.put(&mut writer, 2, &Value::Str("hello!")).expect("write");
+            {
+                let mut iter = s.get(&writer, 1).expect("read");
+                assert_eq!(iter.next().expect("first").expect("ok").1, Some(Value::Str("hello!")));
+                assert_eq!(iter.next().expect("second").expect("ok").1, Some(Value::Str("hello1!")));
+                assert!(iter.next().is_none());
+            }
+            writer.commit().expect("committed");
+        }
+
+        {
+            let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
+            let s = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+
+            let reader = k.read().expect("reader");
+            let mut iter = s.get(&reader, 1).expect("read");
+            assert_eq!(iter.next().expect("first").expect("ok").1, Some(Value::Str("hello!")));
+            assert_eq!(iter.next().expect("second").expect("ok").1, Some(Value::Str("hello1!")));
+            assert!(iter.next().is_none());
+        }
+    }
 }
 
 #[cfg(test)]
@@ -462,6 +496,40 @@ mod tests_safe {
 
             let reader = k.read().expect("reader");
             let mut iter = s.get(&reader, 1).expect("read");
+            assert!(iter.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_persist() {
+        let root = Builder::new().prefix("test_multi_integer_persist").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        {
+            let k = Rkv::new::<backend::SafeMode>(root.path()).expect("new succeeded");
+            let s = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+
+            let mut writer = k.write().expect("writer");
+            s.put(&mut writer, 1, &Value::Str("hello!")).expect("write");
+            s.put(&mut writer, 1, &Value::Str("hello1!")).expect("write");
+            s.put(&mut writer, 2, &Value::Str("hello!")).expect("write");
+            {
+                let mut iter = s.get(&writer, 1).expect("read");
+                assert_eq!(iter.next().expect("first").expect("ok").1, Some(Value::Str("hello!")));
+                assert_eq!(iter.next().expect("second").expect("ok").1, Some(Value::Str("hello1!")));
+                assert!(iter.next().is_none());
+            }
+            writer.commit().expect("committed");
+        }
+
+        {
+            let k = Rkv::new::<backend::SafeMode>(root.path()).expect("new succeeded");
+            let s = k.open_multi_integer("s", StoreOptions::create()).expect("open");
+
+            let reader = k.read().expect("reader");
+            let mut iter = s.get(&reader, 1).expect("read");
+            assert_eq!(iter.next().expect("first").expect("ok").1, Some(Value::Str("hello!")));
+            assert_eq!(iter.next().expect("second").expect("ok").1, Some(Value::Str("hello1!")));
             assert!(iter.next().is_none());
         }
     }

--- a/src/store/multi.rs
+++ b/src/store/multi.rs
@@ -27,6 +27,7 @@ use crate::value::Value;
 
 type EmptyResult = Result<(), StoreError>;
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct MultiStore<D> {
     db: D,
 }

--- a/src/store/single.rs
+++ b/src/store/single.rs
@@ -27,6 +27,7 @@ use crate::value::Value;
 
 type EmptyResult = Result<(), StoreError>;
 
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct SingleStore<D> {
     db: D,
 }

--- a/tests/test_txn.rs
+++ b/tests/test_txn.rs
@@ -48,9 +48,9 @@ fn read_many() {
     let root = Builder::new().prefix("test_txns").tempdir().expect("tempdir");
     fs::create_dir_all(root.path()).expect("dir created");
     let k = Rkv::new::<Lmdb>(root.path()).expect("new succeeded");
-    let samplestore = &k.open_single("s", StoreOptions::create()).expect("open");
-    let datestore = &k.open_multi("m", StoreOptions::create()).expect("open");
-    let valuestore = &k.open_multi("m", StoreOptions::create()).expect("open");
+    let samplestore = k.open_single("s", StoreOptions::create()).expect("open");
+    let datestore = k.open_multi("m", StoreOptions::create()).expect("open");
+    let valuestore = k.open_multi("m", StoreOptions::create()).expect("open");
 
     {
         let mut writer = k.write().expect("env write lock");
@@ -89,7 +89,7 @@ fn read_many() {
     }
 }
 
-fn get_ids_by_field<'env, T>(txn: &'env T, store: &MultiStore, field: &str) -> Vec<u64>
+fn get_ids_by_field<'env, T>(txn: &'env T, store: MultiStore, field: &str) -> Vec<u64>
 where
     T: Readable<'env, Database = LmdbDatabase, RoCursor = LmdbRoCursor<'env>>,
 {
@@ -103,7 +103,7 @@ where
         .collect::<Vec<u64>>()
 }
 
-fn get_samples<'env, T>(txn: &'env T, samplestore: &SingleStore, ids: &[u64]) -> Vec<String>
+fn get_samples<'env, T>(txn: &'env T, samplestore: SingleStore, ids: &[u64]) -> Vec<String>
 where
     T: Readable<'env, Database = LmdbDatabase, RoCursor = LmdbRoCursor<'env>>,
 {
@@ -119,11 +119,11 @@ where
         .collect::<Vec<String>>()
 }
 
-fn put_sample(txn: &mut Writer<LmdbRwTransaction>, samplestore: &SingleStore, id: u64, value: &str) {
+fn put_sample(txn: &mut Writer<LmdbRwTransaction>, samplestore: SingleStore, id: u64, value: &str) {
     let idbytes = id.to_be_bytes();
     samplestore.put(txn, &idbytes, &Value::Str(value)).expect("put id");
 }
 
-fn put_id_field(txn: &mut Writer<LmdbRwTransaction>, store: &MultiStore, field: &str, id: u64) {
+fn put_id_field(txn: &mut Writer<LmdbRwTransaction>, store: MultiStore, field: &str, id: u64) {
     store.put(txn, field, &Value::U64(id)).expect("put id");
 }


### PR DESCRIPTION
In https://github.com/mozilla/rkv/pull/158#issuecomment-548693019 I've explained why dropping the requirement for `Copy` and `Eq` traits was necessary for database instances.

Turns out I lied. We can use arena allocation and opaque keys as database handles. Doing so allows us to preserve the copy and equality trait requirements on "databases" (as users see them).

This patch does the following:
1. Re-enables copy and equality trait requirements on databases.
2. Returns database handles instead of database instances to consumers, in situations such as calling `open_db` or `create_db` on environments, or when dealing with transactions.
3. Derives copy and equality traits on single/multi database helpers.

This ends up simplifying things quite a lot, removes an entire class of errors, removes a layer of smart pointer indirection, and prevents all the copy/eq regressions from #158.

Depends on https://github.com/mozilla/rkv/pull/159.