### PR TITLE
Prevent needless key/value copies in database methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/tests/envs/*"]
 [features]
 default = ["with-safe-mode"]
 backtrace = ["failure/backtrace", "failure/std"]
-with-safe-mode = ["id-arena", "log", "serde/derive", "serde/rc"]
+with-safe-mode = ["hashbrown/serde", "id-arena", "log", "serde/derive", "serde/rc"]
 with-asan = ["lmdb-rkv/with-asan"]
 with-fuzzer = ["lmdb-rkv/with-fuzzer"]
 with-fuzzer-no-link = ["lmdb-rkv/with-fuzzer-no-link"]
@@ -26,6 +26,7 @@ arrayref = "0.3"
 bincode = "1.0"
 bitflags = "1"
 byteorder = "1"
+hashbrown = { version = "0.6", optional = true }
 id-arena = { version = "2.2", optional = true }
 lazy_static = "1.0"
 lmdb-rkv = "0.12.3"


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

We're using `std::collections::HashMap`'s `Entry` API to store keys/values in our safe mode database implementation. This is more ergonomic than using an imperative API, and more performant in the ideal case.

However, the real world isn't ideal, and we end up needlessly reallocating keys and values when interacting with the database. For example, using the `Entry` API to insert a key/value pair into the database results in a copy of the key when the value was already added. Similarly (in an even worse case scenario), deleting all values matching a key copies the key, and attempts clearing an already empty `BTreeSet` representing our values.

The `Entry` API is long known for having poor performance in those situations, with [many attempts](https://internals.rust-lang.org/t/pre-rfc-abandonning-morals-in-the-name-of-performance-the-raw-entry-api/7043) to fix it. We could opt into using the imperative API instead, but that just makes us less performant in other situations. Luckily, we now have a new `RawEntry` API, added in https://github.com/rust-lang/rust/pull/54043 giving us the tools required to deal with this problem elegantly.

The `RawEntry` API is available in nightlies at the moment; however, we can use it in stable via `std::collections::HashMap`'s backing store [rust-lang/hashbrown](https://github.com/rust-lang/hashbrown).