### PR TITLE
LMDB behavior parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ arrayref = "0.3"
 bincode = "1.0"
 bitflags = "1"
 byteorder = "1"
-hashbrown = { version = "0.6", features = ["serde"] }
 id-arena = "2.2"
 lazy_static = "1.0"
 lmdb-rkv = "0.12.3"

--- a/src/backend/impl_safe/cursor.rs
+++ b/src/backend/impl_safe/cursor.rs
@@ -30,7 +30,7 @@ impl<'env> BackendRoCursor<'env> for RoCursorImpl<'env> {
     {
         // FIXME: Don't allocate.
         let key = key.as_ref().to_vec();
-        IterImpl(Box::new(self.0.iter().skip_while(move |&(k, _)| k != &key[..])))
+        IterImpl(Box::new(self.0.iter().skip_while(move |&(k, _)| k < key.as_slice())))
     }
 
     fn iter_dup_of<K>(&mut self, key: K) -> Self::Iter
@@ -39,7 +39,7 @@ impl<'env> BackendRoCursor<'env> for RoCursorImpl<'env> {
     {
         // FIXME: Don't allocate.
         let key = key.as_ref().to_vec();
-        IterImpl(Box::new(self.0.iter().filter(move |&(k, _)| k == &key[..])))
+        IterImpl(Box::new(self.0.iter().filter(move |&(k, _)| k == key.as_slice())))
     }
 }
 

--- a/src/backend/impl_safe/error.rs
+++ b/src/backend/impl_safe/error.rs
@@ -20,6 +20,7 @@ use crate::error::StoreError;
 pub enum ErrorImpl {
     KeyValuePairNotFound,
     DbPoisonError,
+    DbsFull,
     DbsIllegalOpen,
     DbNotFoundError,
     DbIsForeignError,
@@ -34,6 +35,7 @@ impl fmt::Display for ErrorImpl {
         match self {
             ErrorImpl::KeyValuePairNotFound => write!(fmt, "KeyValuePairNotFound (safe mode)"),
             ErrorImpl::DbPoisonError => write!(fmt, "DbPoisonError (safe mode)"),
+            ErrorImpl::DbsFull => write!(fmt, "DbsFull (safe mode)"),
             ErrorImpl::DbsIllegalOpen => write!(fmt, "DbIllegalOpen (safe mode)"),
             ErrorImpl::DbNotFoundError => write!(fmt, "DbNotFoundError (safe mode)"),
             ErrorImpl::DbIsForeignError => write!(fmt, "DbIsForeignError (safe mode)"),

--- a/src/backend/impl_safe/error.rs
+++ b/src/backend/impl_safe/error.rs
@@ -20,6 +20,7 @@ use crate::error::StoreError;
 pub enum ErrorImpl {
     KeyValuePairNotFound,
     DbPoisonError,
+    DbsIllegalOpen,
     DbNotFoundError,
     DbIsForeignError,
     IoError(io::Error),
@@ -33,6 +34,7 @@ impl fmt::Display for ErrorImpl {
         match self {
             ErrorImpl::KeyValuePairNotFound => write!(fmt, "KeyValuePairNotFound (safe mode)"),
             ErrorImpl::DbPoisonError => write!(fmt, "DbPoisonError (safe mode)"),
+            ErrorImpl::DbsIllegalOpen => write!(fmt, "DbIllegalOpen (safe mode)"),
             ErrorImpl::DbNotFoundError => write!(fmt, "DbNotFoundError (safe mode)"),
             ErrorImpl::DbIsForeignError => write!(fmt, "DbIsForeignError (safe mode)"),
             ErrorImpl::IoError(e) => e.fmt(fmt),

--- a/src/backend/impl_safe/transaction.rs
+++ b/src/backend/impl_safe/transaction.rs
@@ -9,6 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::{
     database::Snapshot,
@@ -30,14 +31,16 @@ use crate::backend::traits::{
 pub struct RoTransactionImpl<'env> {
     env: &'env EnvironmentImpl,
     snapshots: HashMap<DatabaseId, Snapshot>,
+    idx: Arc<()>,
 }
 
 impl<'env> RoTransactionImpl<'env> {
-    pub(crate) fn new(env: &'env EnvironmentImpl) -> Result<RoTransactionImpl<'env>, ErrorImpl> {
+    pub(crate) fn new(env: &'env EnvironmentImpl, idx: Arc<()>) -> Result<RoTransactionImpl<'env>, ErrorImpl> {
         let snapshots = env.dbs()?.iter().map(|(id, db)| (id, db.snapshot())).collect();
         Ok(RoTransactionImpl {
             env,
             snapshots,
+            idx,
         })
     }
 }
@@ -69,14 +72,16 @@ impl<'env> BackendRoCursorTransaction<'env> for RoTransactionImpl<'env> {
 pub struct RwTransactionImpl<'env> {
     env: &'env EnvironmentImpl,
     snapshots: HashMap<DatabaseId, Snapshot>,
+    idx: Arc<()>,
 }
 
 impl<'env> RwTransactionImpl<'env> {
-    pub(crate) fn new(env: &'env EnvironmentImpl) -> Result<RwTransactionImpl<'env>, ErrorImpl> {
+    pub(crate) fn new(env: &'env EnvironmentImpl, idx: Arc<()>) -> Result<RwTransactionImpl<'env>, ErrorImpl> {
         let snapshots = env.dbs()?.iter().map(|(id, db)| (id, db.snapshot())).collect();
         Ok(RwTransactionImpl {
             env,
             snapshots,
+            idx,
         })
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -304,23 +304,37 @@ where
     }
 }
 
+#[cfg(test)]
+macro_rules! make_check_rkv {
+    ($k:ty) => {
+        fn check_rkv(k: &$k) {
+            let _ = k.open_single(None, StoreOptions::create()).expect("created default");
+
+            let s = k.open_single("s", StoreOptions::create()).expect("opened");
+            let reader = k.read().expect("reader");
+
+            let result = s.get(&reader, "foo");
+            assert_eq!(None, result.expect("success but no value"));
+        }
+    };
+}
+
 // TODO: change this back to `clippy::cognitive_complexity` when Clippy stable
 // deprecates `clippy::cyclomatic_complexity`.
 #[allow(clippy::complexity)]
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::str;
+    use std::sync::{
+        Arc,
+        RwLock,
+    };
+    use std::thread;
+
     use byteorder::{
         ByteOrder,
         LittleEndian,
-    };
-    use std::{
-        fs,
-        str,
-        sync::{
-            Arc,
-            RwLock,
-        },
-        thread,
     };
     use tempfile::Builder;
 
@@ -332,6 +346,8 @@ mod tests {
         LmdbEnvironment,
         LmdbRwTransaction,
     };
+
+    make_check_rkv!(Rkv<LmdbEnvironment>);
 
     // The default size is 1MB.
     const DEFAULT_SIZE: usize = 1024 * 1024;
@@ -354,16 +370,6 @@ mod tests {
         };
     }
 
-    fn check_rkv(k: &Rkv<LmdbEnvironment>) {
-        let _ = k.open_single("default", StoreOptions::create()).expect("created default");
-
-        let yyy = k.open_single("yyy", StoreOptions::create()).expect("opened");
-        let reader = k.read().expect("reader");
-
-        let result = yyy.get(&reader, "foo");
-        assert_eq!(None, result.expect("success but no value"));
-    }
-
     #[test]
     fn test_open() {
         let root = Builder::new().prefix("test_open").tempdir().expect("tempdir");
@@ -372,7 +378,6 @@ mod tests {
         assert!(root.path().is_dir());
 
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
-
         check_rkv(&k);
     }
 
@@ -385,8 +390,8 @@ mod tests {
 
         let mut builder = Rkv::environment_builder::<backend::Lmdb>();
         builder.set_max_dbs(2);
-        let k = Rkv::from_builder(root.path(), builder).expect("rkv");
 
+        let k = Rkv::from_builder(root.path(), builder).expect("rkv");
         check_rkv(&k);
     }
 
@@ -399,7 +404,6 @@ mod tests {
         assert!(root.path().is_dir());
 
         let k = Rkv::with_capacity::<backend::Lmdb>(root.path(), 1).expect("rkv");
-
         check_rkv(&k);
 
         // This panics with "opened: LmdbError(DbsFull)" because we specified
@@ -485,8 +489,8 @@ mod tests {
     fn test_round_trip_and_transactions() {
         let root = Builder::new().prefix("test_round_trip_and_transactions").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
-        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
 
+        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
 
         {
@@ -529,6 +533,7 @@ mod tests {
         }
 
         // Committed. Reads will succeed.
+
         {
             let r = k.read().unwrap();
             assert_eq!(sk.get(&r, "foo").expect("read"), Some(Value::I64(1234)));
@@ -574,6 +579,7 @@ mod tests {
         }
 
         // Committed. Reads will succeed but return None to indicate a missing value.
+
         {
             let r = k.read().unwrap();
             assert_eq!(sk.get(&r, "foo").expect("read"), None);
@@ -586,8 +592,8 @@ mod tests {
     fn test_single_store_clear() {
         let root = Builder::new().prefix("test_single_store_clear").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
-        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
 
+        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
 
         {
@@ -615,8 +621,10 @@ mod tests {
     fn test_multi_put_get_del() {
         let root = Builder::new().prefix("test_multi_put_get_del").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let multistore = k.open_multi("multistore", StoreOptions::create()).unwrap();
+
         let mut writer = k.write().unwrap();
         multistore.put(&mut writer, "str1", &Value::Str("str1 foo")).unwrap();
         multistore.put(&mut writer, "str1", &Value::Str("str1 bar")).unwrap();
@@ -625,6 +633,7 @@ mod tests {
         multistore.put(&mut writer, "str3", &Value::Str("str3 foo")).unwrap();
         multistore.put(&mut writer, "str3", &Value::Str("str3 bar")).unwrap();
         writer.commit().unwrap();
+
         let writer = k.write().unwrap();
         {
             let mut iter = multistore.get(&writer, "str1").unwrap();
@@ -634,14 +643,12 @@ mod tests {
             assert_eq!((id, val), (&b"str1"[..], Some(Value::Str("str1 foo"))));
         }
         writer.commit().unwrap();
-        let mut writer = k.write().unwrap();
 
+        let mut writer = k.write().unwrap();
         multistore.delete(&mut writer, "str1", &Value::Str("str1 foo")).unwrap();
         assert_eq!(multistore.get_first(&writer, "str1").unwrap(), Some(Value::Str("str1 bar")));
-
         multistore.delete(&mut writer, "str2", &Value::Str("str2 bar")).unwrap();
         assert_eq!(multistore.get_first(&writer, "str2").unwrap(), Some(Value::Str("str2 foo")));
-
         multistore.delete_all(&mut writer, "str3").unwrap();
         assert_eq!(multistore.get_first(&writer, "str3").unwrap(), None);
         writer.commit().unwrap();
@@ -651,8 +658,8 @@ mod tests {
     fn test_multiple_store_clear() {
         let root = Builder::new().prefix("test_multiple_store_clear").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
-        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
 
+        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let multistore = k.open_multi("multistore", StoreOptions::create()).expect("opened");
 
         {
@@ -684,7 +691,9 @@ mod tests {
     fn test_open_store_for_read() {
         let root = Builder::new().prefix("test_open_store_for_read").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
+
         // First create the store, and start a write transaction on it.
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
         let mut writer = k.write().expect("writer");
@@ -694,6 +703,7 @@ mod tests {
         // it should not block the reader though.
         let sk_readonly = k.open_single("sk", StoreOptions::default()).expect("opened");
         writer.commit().expect("commit");
+
         // Now the write transaction is committed, any followed reads should see its change.
         let reader = k.read().expect("reader");
         assert_eq!(sk_readonly.get(&reader, "foo").expect("read"), Some(Value::Str("bar")));
@@ -704,6 +714,7 @@ mod tests {
     fn test_open_a_missing_store() {
         let root = Builder::new().prefix("test_open_a_missing_store").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let _sk = k.open("sk", StoreOptions::default()).expect("open a missing store");
     }
@@ -712,11 +723,15 @@ mod tests {
     fn test_open_fail_with_badrslot() {
         let root = Builder::new().prefix("test_open_fail_with_badrslot").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
+
         // First create the store
         let _sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
         // Open a reader on this store
         let _reader = k.read().expect("reader");
+
         // Open the same store for read while the reader is in progress will panic
         let store = k.open_single("sk", StoreOptions::default());
         match store {
@@ -729,6 +744,7 @@ mod tests {
     fn test_read_before_write_num() {
         let root = Builder::new().prefix("test_read_before_write_num").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
 
@@ -758,6 +774,7 @@ mod tests {
     fn test_read_before_write_str() {
         let root = Builder::new().prefix("test_read_before_write_str").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
 
@@ -766,14 +783,20 @@ mod tests {
         // as the Value::Str (and its underlying &str) borrows an immutable
         // reference to the Writer.  So we copy it to a String.
 
-        let mut writer = k.write().expect("writer");
-        let mut existing = match sk.get(&writer, "foo").expect("read") {
-            Some(Value::Str(val)) => val,
-            _ => "",
+        fn get_existing_foo(store: SingleStore<LmdbDatabase>, writer: &Writer<LmdbRwTransaction>) -> Option<String> {
+            match store.get(writer, "foo").expect("read") {
+                Some(Value::Str(val)) => Some(val.to_string()),
+                _ => None,
+            }
         }
-        .to_string();
+
+        let mut writer = k.write().expect("writer");
+        let mut existing = get_existing_foo(sk, &writer).unwrap_or_default();
         existing.push('…');
         sk.put(&mut writer, "foo", &Value::Str(&existing)).expect("write");
+
+        let updated = get_existing_foo(sk, &writer).unwrap_or_default();
+        assert_eq!(updated, "…");
         writer.commit().expect("commit");
     }
 
@@ -781,8 +804,8 @@ mod tests {
     fn test_concurrent_read_transactions_prohibited() {
         let root = Builder::new().prefix("test_concurrent_reads_prohibited").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
-        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
 
+        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let _first = k.read().expect("reader");
         let second = k.read();
 
@@ -803,6 +826,7 @@ mod tests {
     fn test_isolation() {
         let root = Builder::new().prefix("test_isolation").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let s = k.open_single("s", StoreOptions::create()).expect("opened");
 
@@ -845,10 +869,11 @@ mod tests {
     fn test_blob() {
         let root = Builder::new().prefix("test_round_trip_blob").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
-        let mut writer = k.write().expect("writer");
 
+        let mut writer = k.write().expect("writer");
         assert_eq!(sk.get(&writer, "foo").expect("read"), None);
         sk.put(&mut writer, "foo", &Value::Blob(&[1, 2, 3, 4])).expect("wrote");
         assert_eq!(sk.get(&writer, "foo").expect("read"), Some(Value::Blob(&[1, 2, 3, 4])));
@@ -882,13 +907,13 @@ mod tests {
     fn test_sync() {
         let root = Builder::new().prefix("test_sync").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let mut builder = Rkv::environment_builder::<backend::Lmdb>();
         builder.set_max_dbs(1);
         builder.set_flags(EnvironmentFlags::NO_SYNC);
         {
             let k = Rkv::from_builder(root.path(), builder).expect("new succeeded");
             let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
-
             {
                 let mut writer = k.write().expect("writer");
                 sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
@@ -906,6 +931,7 @@ mod tests {
     fn test_stat() {
         let root = Builder::new().prefix("test_stat").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         for i in 0..5 {
             let sk = k.open_integer(&format!("sk{}", i)[..], StoreOptions::create()).expect("opened");
@@ -925,10 +951,11 @@ mod tests {
     fn test_info() {
         let root = Builder::new().prefix("test_info").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
-        let mut writer = k.write().expect("writer");
 
+        let mut writer = k.write().expect("writer");
         sk.put(&mut writer, "foo", &Value::Str("bar")).expect("wrote");
         writer.commit().expect("commited");
 
@@ -955,12 +982,13 @@ mod tests {
     fn test_load_ratio() {
         let root = Builder::new().prefix("test_load_ratio").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
         let mut writer = k.write().expect("writer");
         sk.put(&mut writer, "foo", &Value::Str("bar")).expect("wrote");
         writer.commit().expect("commited");
-
         let ratio = k.load_ratio().expect("ratio");
         assert!(ratio > 0.0_f32 && ratio < 1.0_f32);
 
@@ -984,6 +1012,7 @@ mod tests {
     fn test_set_map_size() {
         let root = Builder::new().prefix("test_size_map_size").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
 
@@ -1003,6 +1032,7 @@ mod tests {
     fn test_iter() {
         let root = Builder::new().prefix("test_iter").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
 
@@ -1096,8 +1126,8 @@ mod tests {
     fn test_multiple_store_read_write() {
         let root = Builder::new().prefix("test_multiple_store_read_write").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
-        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
 
+        let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let s1 = k.open_single("store_1", StoreOptions::create()).expect("opened");
         let s2 = k.open_single("store_2", StoreOptions::create()).expect("opened");
         let s3 = k.open_single("store_3", StoreOptions::create()).expect("opened");
@@ -1136,6 +1166,7 @@ mod tests {
     fn test_multiple_store_iter() {
         let root = Builder::new().prefix("test_multiple_store_iter").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let k = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
         let s1 = k.open_single("store_1", StoreOptions::create()).expect("opened");
         let s2 = k.open_single("store_2", StoreOptions::create()).expect("opened");
@@ -1248,6 +1279,7 @@ mod tests {
     fn test_store_multiple_thread() {
         let root = Builder::new().prefix("test_multiple_thread").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
+
         let rkv_arc = Arc::new(RwLock::new(Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded")));
         let store = rkv_arc.read().unwrap().open_single("test", StoreOptions::create()).expect("opened");
 
@@ -1302,6 +1334,906 @@ mod tests {
     fn test_use_value_as_key() {
         let root = Builder::new().prefix("test_use_value_as_key").tempdir().expect("tempdir");
         let rkv = Rkv::new::<backend::Lmdb>(root.path()).expect("new succeeded");
+        let store = rkv.open_single("store", StoreOptions::create()).expect("opened");
+
+        {
+            let mut writer = rkv.write().expect("writer");
+            store.put(&mut writer, "foo", &Value::Str("bar")).expect("wrote");
+            store.put(&mut writer, "bar", &Value::Str("baz")).expect("wrote");
+            writer.commit().expect("committed");
+        }
+
+        // It's possible to retrieve a value with a Reader and then use it
+        // as a key with a Writer.
+        {
+            let reader = &rkv.read().unwrap();
+            if let Some(Value::Str(key)) = store.get(reader, "foo").expect("read") {
+                let mut writer = rkv.write().expect("writer");
+                store.delete(&mut writer, key).expect("deleted");
+                writer.commit().expect("committed");
+            }
+        }
+
+        {
+            let mut writer = rkv.write().expect("writer");
+            store.put(&mut writer, "bar", &Value::Str("baz")).expect("wrote");
+            writer.commit().expect("committed");
+        }
+
+        // You can also retrieve a Value with a Writer and then use it as a key
+        // with the same Writer if you copy the value to an owned type
+        // so the Writer isn't still being borrowed by the retrieved value
+        // when you try to borrow the Writer again to modify that value.
+        {
+            let mut writer = rkv.write().expect("writer");
+            if let Some(Value::Str(value)) = store.get(&writer, "foo").expect("read") {
+                let key = value.to_owned();
+                store.delete(&mut writer, key).expect("deleted");
+                writer.commit().expect("committed");
+            }
+        }
+
+        {
+            let name1 = rkv.open_single("name1", StoreOptions::create()).expect("opened");
+            let name2 = rkv.open_single("name2", StoreOptions::create()).expect("opened");
+            let mut writer = rkv.write().expect("writer");
+            name1.put(&mut writer, "key1", &Value::Str("bar")).expect("wrote");
+            name1.put(&mut writer, "bar", &Value::Str("baz")).expect("wrote");
+            name2.put(&mut writer, "key2", &Value::Str("bar")).expect("wrote");
+            name2.put(&mut writer, "bar", &Value::Str("baz")).expect("wrote");
+            writer.commit().expect("committed");
+        }
+
+        // You can also iterate (store, key) pairs to retrieve foreign keys,
+        // then iterate those foreign keys to modify/delete them.
+        //
+        // You need to open the stores in advance, since opening a store
+        // uses a write transaction internally, so opening them while a writer
+        // is extant will hang.
+        //
+        // And you need to copy the values to an owned type so the Writer isn't
+        // still being borrowed by a retrieved value when you try to borrow
+        // the Writer again to modify another value.
+        let fields = vec![
+            (rkv.open_single("name1", StoreOptions::create()).expect("opened"), "key1"),
+            (rkv.open_single("name2", StoreOptions::create()).expect("opened"), "key2"),
+        ];
+        {
+            let mut foreignkeys = Vec::new();
+            let mut writer = rkv.write().expect("writer");
+            for (store, key) in fields.iter() {
+                if let Some(Value::Str(value)) = store.get(&writer, key).expect("read") {
+                    foreignkeys.push((store, value.to_owned()));
+                }
+            }
+            for (store, key) in foreignkeys.iter() {
+                store.delete(&mut writer, key).expect("deleted");
+            }
+            writer.commit().expect("committed");
+        }
+    }
+}
+
+// TODO: change this back to `clippy::cognitive_complexity` when Clippy stable
+// deprecates `clippy::cyclomatic_complexity`.
+#[allow(clippy::complexity)]
+#[cfg(test)]
+mod tests_safe {
+    use std::fs;
+    use std::str;
+    use std::sync::{
+        Arc,
+        RwLock,
+    };
+    use std::thread;
+
+    use byteorder::{
+        ByteOrder,
+        LittleEndian,
+    };
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::*;
+
+    use crate::backend::{
+        SafeMode,
+        SafeModeDatabase,
+        SafeModeEnvironment,
+        SafeModeRwTransaction,
+    };
+
+    make_check_rkv!(Rkv<SafeModeEnvironment>);
+
+    /// We can't open a directory that doesn't exist.
+    #[test]
+    fn test_open_fails_safe() {
+        let root = Builder::new().prefix("test_open_fails_safe").tempdir().expect("tempdir");
+        assert!(root.path().exists());
+
+        let nope = root.path().join("nope/");
+        assert!(!nope.exists());
+
+        let pb = nope.to_path_buf();
+        match Rkv::new::<SafeMode>(nope.as_path()).err() {
+            Some(StoreError::DirectoryDoesNotExistError(p)) => {
+                assert_eq!(pb, p);
+            },
+            _ => panic!("expected error"),
+        };
+    }
+
+    #[test]
+    fn test_open_safe() {
+        let root = Builder::new().prefix("test_open_safe").tempdir().expect("tempdir");
+        println!("Root path: {:?}", root.path());
+        fs::create_dir_all(root.path()).expect("dir created");
+        assert!(root.path().is_dir());
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        check_rkv(&k);
+    }
+
+    #[test]
+    fn test_open_from_builder_safe() {
+        let root = Builder::new().prefix("test_open_from_builder_safe").tempdir().expect("tempdir");
+        println!("Root path: {:?}", root.path());
+        fs::create_dir_all(root.path()).expect("dir created");
+        assert!(root.path().is_dir());
+
+        let mut builder = Rkv::environment_builder::<SafeMode>();
+        builder.set_max_dbs(2);
+
+        let k = Rkv::from_builder(root.path(), builder).expect("rkv");
+        check_rkv(&k);
+    }
+
+    #[test]
+    #[should_panic(expected = "opened: SafeModeError(DbsFull)")]
+    fn test_open_with_capacity_safe() {
+        let root = Builder::new().prefix("test_open_with_capacity").tempdir().expect("tempdir");
+        println!("Root path: {:?}", root.path());
+        fs::create_dir_all(root.path()).expect("dir created");
+        assert!(root.path().is_dir());
+
+        let k = Rkv::with_capacity::<SafeMode>(root.path(), 1).expect("rkv");
+        check_rkv(&k);
+
+        let _zzz = k.open_single("zzz", StoreOptions::create()).expect("opened");
+    }
+
+    #[test]
+    fn test_round_trip_and_transactions_safe() {
+        let root = Builder::new().prefix("test_round_trip_and_transactions_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        {
+            let mut writer = k.write().expect("writer");
+            sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+            sk.put(&mut writer, "noo", &Value::F64(1234.0.into())).expect("wrote");
+            sk.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+            sk.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+            assert_eq!(sk.get(&writer, "foo").expect("read"), Some(Value::I64(1234)));
+            assert_eq!(sk.get(&writer, "noo").expect("read"), Some(Value::F64(1234.0.into())));
+            assert_eq!(sk.get(&writer, "bar").expect("read"), Some(Value::Bool(true)));
+            assert_eq!(sk.get(&writer, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+
+            // Isolation. Reads won't return values.
+            let r = &k.read().unwrap();
+            assert_eq!(sk.get(r, "foo").expect("read"), None);
+            assert_eq!(sk.get(r, "bar").expect("read"), None);
+            assert_eq!(sk.get(r, "baz").expect("read"), None);
+        }
+
+        // Dropped: tx rollback. Reads will still return nothing.
+
+        {
+            let r = &k.read().unwrap();
+            assert_eq!(sk.get(r, "foo").expect("read"), None);
+            assert_eq!(sk.get(r, "bar").expect("read"), None);
+            assert_eq!(sk.get(r, "baz").expect("read"), None);
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+            sk.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+            sk.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+            assert_eq!(sk.get(&writer, "foo").expect("read"), Some(Value::I64(1234)));
+            assert_eq!(sk.get(&writer, "bar").expect("read"), Some(Value::Bool(true)));
+            assert_eq!(sk.get(&writer, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+
+            writer.commit().expect("committed");
+        }
+
+        // Committed. Reads will succeed.
+
+        {
+            let r = k.read().unwrap();
+            assert_eq!(sk.get(&r, "foo").expect("read"), Some(Value::I64(1234)));
+            assert_eq!(sk.get(&r, "bar").expect("read"), Some(Value::Bool(true)));
+            assert_eq!(sk.get(&r, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            sk.delete(&mut writer, "foo").expect("deleted");
+            sk.delete(&mut writer, "bar").expect("deleted");
+            sk.delete(&mut writer, "baz").expect("deleted");
+            assert_eq!(sk.get(&writer, "foo").expect("read"), None);
+            assert_eq!(sk.get(&writer, "bar").expect("read"), None);
+            assert_eq!(sk.get(&writer, "baz").expect("read"), None);
+
+            // Isolation. Reads still return values.
+            let r = k.read().unwrap();
+            assert_eq!(sk.get(&r, "foo").expect("read"), Some(Value::I64(1234)));
+            assert_eq!(sk.get(&r, "bar").expect("read"), Some(Value::Bool(true)));
+            assert_eq!(sk.get(&r, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+        }
+
+        // Dropped: tx rollback. Reads will still return values.
+
+        {
+            let r = k.read().unwrap();
+            assert_eq!(sk.get(&r, "foo").expect("read"), Some(Value::I64(1234)));
+            assert_eq!(sk.get(&r, "bar").expect("read"), Some(Value::Bool(true)));
+            assert_eq!(sk.get(&r, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            sk.delete(&mut writer, "foo").expect("deleted");
+            sk.delete(&mut writer, "bar").expect("deleted");
+            sk.delete(&mut writer, "baz").expect("deleted");
+            assert_eq!(sk.get(&writer, "foo").expect("read"), None);
+            assert_eq!(sk.get(&writer, "bar").expect("read"), None);
+            assert_eq!(sk.get(&writer, "baz").expect("read"), None);
+
+            writer.commit().expect("committed");
+        }
+
+        // Committed. Reads will succeed but return None to indicate a missing value.
+
+        {
+            let r = k.read().unwrap();
+            assert_eq!(sk.get(&r, "foo").expect("read"), None);
+            assert_eq!(sk.get(&r, "bar").expect("read"), None);
+            assert_eq!(sk.get(&r, "baz").expect("read"), None);
+        }
+    }
+
+    #[test]
+    fn test_single_store_clear_safe() {
+        let root = Builder::new().prefix("test_single_store_clear_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        {
+            let mut writer = k.write().expect("writer");
+            sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+            sk.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+            sk.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            sk.clear(&mut writer).expect("cleared");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let r = k.read().unwrap();
+            let iter = sk.iter_start(&r).expect("iter");
+            assert_eq!(iter.count(), 0);
+        }
+    }
+
+    #[test]
+    fn test_multi_put_get_del_safe() {
+        let root = Builder::new().prefix("test_multi_put_get_del_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let multistore = k.open_multi("multistore", StoreOptions::create()).unwrap();
+
+        let mut writer = k.write().unwrap();
+        multistore.put(&mut writer, "str1", &Value::Str("str1 foo")).unwrap();
+        multistore.put(&mut writer, "str1", &Value::Str("str1 bar")).unwrap();
+        multistore.put(&mut writer, "str2", &Value::Str("str2 foo")).unwrap();
+        multistore.put(&mut writer, "str2", &Value::Str("str2 bar")).unwrap();
+        multistore.put(&mut writer, "str3", &Value::Str("str3 foo")).unwrap();
+        multistore.put(&mut writer, "str3", &Value::Str("str3 bar")).unwrap();
+        writer.commit().unwrap();
+
+        let writer = k.write().unwrap();
+        {
+            let mut iter = multistore.get(&writer, "str1").unwrap();
+            let (id, val) = iter.next().unwrap().unwrap();
+            assert_eq!((id, val), (&b"str1"[..], Some(Value::Str("str1 bar"))));
+            let (id, val) = iter.next().unwrap().unwrap();
+            assert_eq!((id, val), (&b"str1"[..], Some(Value::Str("str1 foo"))));
+        }
+        writer.commit().unwrap();
+
+        let mut writer = k.write().unwrap();
+        multistore.delete(&mut writer, "str1", &Value::Str("str1 foo")).unwrap();
+        assert_eq!(multistore.get_first(&writer, "str1").unwrap(), Some(Value::Str("str1 bar")));
+        multistore.delete(&mut writer, "str2", &Value::Str("str2 bar")).unwrap();
+        assert_eq!(multistore.get_first(&writer, "str2").unwrap(), Some(Value::Str("str2 foo")));
+        multistore.delete_all(&mut writer, "str3").unwrap();
+        assert_eq!(multistore.get_first(&writer, "str3").unwrap(), None);
+        writer.commit().unwrap();
+    }
+
+    #[test]
+    fn test_multiple_store_clear_safe() {
+        let root = Builder::new().prefix("test_multiple_store_clear_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let multistore = k.open_multi("multistore", StoreOptions::create()).expect("opened");
+
+        {
+            let mut writer = k.write().expect("writer");
+            multistore.put(&mut writer, "str1", &Value::Str("str1 foo")).unwrap();
+            multistore.put(&mut writer, "str1", &Value::Str("str1 bar")).unwrap();
+            multistore.put(&mut writer, "str2", &Value::Str("str2 foo")).unwrap();
+            multistore.put(&mut writer, "str2", &Value::Str("str2 bar")).unwrap();
+            multistore.put(&mut writer, "str3", &Value::Str("str3 foo")).unwrap();
+            multistore.put(&mut writer, "str3", &Value::Str("str3 bar")).unwrap();
+            writer.commit().expect("committed");
+        }
+
+        {
+            let mut writer = k.write().expect("writer");
+            multistore.clear(&mut writer).expect("cleared");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let r = k.read().unwrap();
+            assert_eq!(multistore.get_first(&r, "str1").expect("read"), None);
+            assert_eq!(multistore.get_first(&r, "str2").expect("read"), None);
+            assert_eq!(multistore.get_first(&r, "str3").expect("read"), None);
+        }
+    }
+
+    #[test]
+    fn test_open_store_for_read_safe() {
+        let root = Builder::new().prefix("test_open_store_for_read_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+
+        // First create the store, and start a write transaction on it.
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+        let mut writer = k.write().expect("writer");
+        sk.put(&mut writer, "foo", &Value::Str("bar")).expect("write");
+
+        // Open the same store for read, note that the write transaction is still in progress,
+        // it should not block the reader though.
+        let sk_readonly = k.open_single("sk", StoreOptions::default()).expect("opened");
+        writer.commit().expect("commit");
+
+        // Now the write transaction is committed, any followed reads should see its change.
+        let reader = k.read().expect("reader");
+        assert_eq!(sk_readonly.get(&reader, "foo").expect("read"), Some(Value::Str("bar")));
+    }
+
+    #[test]
+    #[should_panic(expected = "open a missing store")]
+    fn test_open_a_missing_store_safe() {
+        let root = Builder::new().prefix("test_open_a_missing_store_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let _sk = k.open("sk", StoreOptions::default()).expect("open a missing store");
+    }
+
+    #[test]
+    fn test_open_fail_with_badrslot_safe() {
+        let root = Builder::new().prefix("test_open_fail_with_badrslot_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+
+        // First create the store
+        let _sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        // Open a reader on this store
+        let _reader = k.read().expect("reader");
+
+        // Open the same store for read while the reader is in progress will panic
+        let store = k.open_single("sk", StoreOptions::default());
+        match store {
+            Err(StoreError::OpenAttemptedDuringTransaction(_thread_id)) => (),
+            _ => panic!("should panic"),
+        }
+    }
+
+    #[test]
+    fn test_read_before_write_num_safe() {
+        let root = Builder::new().prefix("test_read_before_write_num_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        // Test reading a number, modifying it, and then writing it back.
+        // We have to be done with the Value::I64 before calling Writer::put,
+        // as the Value::I64 borrows an immutable reference to the Writer.
+        // So we extract and copy its primitive value.
+
+        fn get_existing_foo(
+            store: SingleStore<SafeModeDatabase>,
+            writer: &Writer<SafeModeRwTransaction>,
+        ) -> Option<i64> {
+            match store.get(writer, "foo").expect("read") {
+                Some(Value::I64(val)) => Some(val),
+                _ => None,
+            }
+        }
+
+        let mut writer = k.write().expect("writer");
+        let mut existing = get_existing_foo(sk, &writer).unwrap_or(99);
+        existing += 1;
+        sk.put(&mut writer, "foo", &Value::I64(existing)).expect("success");
+
+        let updated = get_existing_foo(sk, &writer).unwrap_or(99);
+        assert_eq!(updated, 100);
+        writer.commit().expect("commit");
+    }
+
+    #[test]
+    fn test_read_before_write_str_safe() {
+        let root = Builder::new().prefix("test_read_before_write_str_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        // Test reading a string, modifying it, and then writing it back.
+        // We have to be done with the Value::Str before calling Writer::put,
+        // as the Value::Str (and its underlying &str) borrows an immutable
+        // reference to the Writer.  So we copy it to a String.
+
+        fn get_existing_foo(
+            store: SingleStore<SafeModeDatabase>,
+            writer: &Writer<SafeModeRwTransaction>,
+        ) -> Option<String> {
+            match store.get(writer, "foo").expect("read") {
+                Some(Value::Str(val)) => Some(val.to_string()),
+                _ => None,
+            }
+        }
+
+        let mut writer = k.write().expect("writer");
+        let mut existing = get_existing_foo(sk, &writer).unwrap_or_default();
+        existing.push('…');
+        sk.put(&mut writer, "foo", &Value::Str(&existing)).expect("write");
+
+        let updated = get_existing_foo(sk, &writer).unwrap_or_default();
+        assert_eq!(updated, "…");
+        writer.commit().expect("commit");
+    }
+
+    #[test]
+    fn test_isolation_safe() {
+        let root = Builder::new().prefix("test_isolation_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let s = k.open_single("s", StoreOptions::create()).expect("opened");
+
+        // Add one field.
+        {
+            let mut writer = k.write().expect("writer");
+            s.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+            writer.commit().expect("committed");
+        }
+
+        {
+            let reader = k.read().unwrap();
+            assert_eq!(s.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+        }
+
+        // Establish a long-lived reader that outlasts a writer.
+        let reader = k.read().expect("reader");
+        assert_eq!(s.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+
+        // Start a write transaction.
+        let mut writer = k.write().expect("writer");
+        s.put(&mut writer, "foo", &Value::I64(999)).expect("wrote");
+
+        // The reader and writer are isolated.
+        assert_eq!(s.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+        assert_eq!(s.get(&writer, "foo").expect("read"), Some(Value::I64(999)));
+
+        // If we commit the writer, we still have isolation.
+        writer.commit().expect("committed");
+        assert_eq!(s.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+
+        // A new reader sees the committed value. Note that LMDB doesn't allow two
+        // read transactions to exist in the same thread, so we abort the previous one.
+        reader.abort();
+        let reader = k.read().expect("reader");
+        assert_eq!(s.get(&reader, "foo").expect("read"), Some(Value::I64(999)));
+    }
+
+    #[test]
+    fn test_blob_safe() {
+        let root = Builder::new().prefix("test_round_trip_blob_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        let mut writer = k.write().expect("writer");
+        assert_eq!(sk.get(&writer, "foo").expect("read"), None);
+        sk.put(&mut writer, "foo", &Value::Blob(&[1, 2, 3, 4])).expect("wrote");
+        assert_eq!(sk.get(&writer, "foo").expect("read"), Some(Value::Blob(&[1, 2, 3, 4])));
+
+        fn u16_to_u8(src: &[u16]) -> Vec<u8> {
+            let mut dst = vec![0; 2 * src.len()];
+            LittleEndian::write_u16_into(src, &mut dst);
+            dst
+        }
+
+        fn u8_to_u16(src: &[u8]) -> Vec<u16> {
+            let mut dst = vec![0; src.len() / 2];
+            LittleEndian::read_u16_into(src, &mut dst);
+            dst
+        }
+
+        // When storing UTF-16 strings as blobs, we'll need to convert
+        // their [u16] backing storage to [u8].  Test that converting, writing,
+        // reading, and converting back works as expected.
+        let u16_array = [1000, 10000, 54321, 65535];
+        assert_eq!(sk.get(&writer, "bar").expect("read"), None);
+        sk.put(&mut writer, "bar", &Value::Blob(&u16_to_u8(&u16_array))).expect("wrote");
+        let u8_array = match sk.get(&writer, "bar").expect("read") {
+            Some(Value::Blob(val)) => val,
+            _ => &[],
+        };
+        assert_eq!(u8_to_u16(u8_array), u16_array);
+    }
+
+    #[test]
+    fn test_sync_safe() {
+        let root = Builder::new().prefix("test_sync_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let mut builder = Rkv::environment_builder::<SafeMode>();
+        builder.set_max_dbs(1);
+        {
+            let k = Rkv::from_builder(root.path(), builder).expect("new succeeded");
+            let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+            {
+                let mut writer = k.write().expect("writer");
+                sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+                writer.commit().expect("committed");
+                k.sync(true).expect("synced");
+            }
+        }
+        let k = Rkv::from_builder(root.path(), builder).expect("new succeeded");
+        let sk = k.open_single("sk", StoreOptions::default()).expect("opened");
+        let reader = k.read().expect("reader");
+        assert_eq!(sk.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+    }
+
+    #[test]
+    fn test_iter_safe() {
+        let root = Builder::new().prefix("test_iter_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        // An iterator over an empty store returns no values.
+        {
+            let reader = k.read().unwrap();
+            let mut iter = sk.iter_start(&reader).unwrap();
+            assert!(iter.next().is_none());
+        }
+
+        let mut writer = k.write().expect("writer");
+        sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+        sk.put(&mut writer, "noo", &Value::F64(1234.0.into())).expect("wrote");
+        sk.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+        sk.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+        sk.put(&mut writer, "héllò, töűrîst", &Value::Str("Emil.RuleZ!")).expect("wrote");
+        sk.put(&mut writer, "你好，遊客", &Value::Str("米克規則")).expect("wrote");
+        writer.commit().expect("committed");
+
+        let reader = k.read().unwrap();
+
+        // Reader.iter() returns (key, value) tuples ordered by key.
+        let mut iter = sk.iter_start(&reader).unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "bar");
+        assert_eq!(val, Some(Value::Bool(true)));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "baz");
+        assert_eq!(val, Some(Value::Str("héllo, yöu")));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "foo");
+        assert_eq!(val, Some(Value::I64(1234)));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "héllò, töűrîst");
+        assert_eq!(val, Some(Value::Str("Emil.RuleZ!")));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+
+        // Iterators don't loop.  Once one returns None, additional calls
+        // to its next() method will always return None.
+        assert!(iter.next().is_none());
+
+        // Reader.iter_from() begins iteration at the first key equal to
+        // or greater than the given key.
+        let mut iter = sk.iter_from(&reader, "moo").unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+
+        // Reader.iter_from() works as expected when the given key is a prefix
+        // of a key in the store.
+        let mut iter = sk.iter_from(&reader, "no").unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_iter_from_key_greater_than_existing_safe() {
+        let root = Builder::new().prefix("test_iter_from_key_greater_than_existing_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let sk = k.open_single("sk", StoreOptions::create()).expect("opened");
+
+        let mut writer = k.write().expect("writer");
+        sk.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+        sk.put(&mut writer, "noo", &Value::F64(1234.0.into())).expect("wrote");
+        sk.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+        sk.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+        writer.commit().expect("committed");
+
+        let reader = k.read().unwrap();
+        let mut iter = sk.iter_from(&reader, "nuu").unwrap();
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_multiple_store_read_write_safe() {
+        let root = Builder::new().prefix("test_multiple_store_read_write_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let s1 = k.open_single("store_1", StoreOptions::create()).expect("opened");
+        let s2 = k.open_single("store_2", StoreOptions::create()).expect("opened");
+        let s3 = k.open_single("store_3", StoreOptions::create()).expect("opened");
+
+        let mut writer = k.write().expect("writer");
+        s1.put(&mut writer, "foo", &Value::Str("bar")).expect("wrote");
+        s2.put(&mut writer, "foo", &Value::I64(123)).expect("wrote");
+        s3.put(&mut writer, "foo", &Value::Bool(true)).expect("wrote");
+
+        assert_eq!(s1.get(&writer, "foo").expect("read"), Some(Value::Str("bar")));
+        assert_eq!(s2.get(&writer, "foo").expect("read"), Some(Value::I64(123)));
+        assert_eq!(s3.get(&writer, "foo").expect("read"), Some(Value::Bool(true)));
+
+        writer.commit().expect("committed");
+
+        let reader = k.read().expect("unbound_reader");
+        assert_eq!(s1.get(&reader, "foo").expect("read"), Some(Value::Str("bar")));
+        assert_eq!(s2.get(&reader, "foo").expect("read"), Some(Value::I64(123)));
+        assert_eq!(s3.get(&reader, "foo").expect("read"), Some(Value::Bool(true)));
+        reader.abort();
+
+        // test delete across multiple stores
+        let mut writer = k.write().expect("writer");
+        s1.delete(&mut writer, "foo").expect("deleted");
+        s2.delete(&mut writer, "foo").expect("deleted");
+        s3.delete(&mut writer, "foo").expect("deleted");
+        writer.commit().expect("committed");
+
+        let reader = k.read().expect("reader");
+        assert_eq!(s1.get(&reader, "key").expect("value"), None);
+        assert_eq!(s2.get(&reader, "key").expect("value"), None);
+        assert_eq!(s3.get(&reader, "key").expect("value"), None);
+    }
+
+    #[test]
+    fn test_multiple_store_iter_safe() {
+        let root = Builder::new().prefix("test_multiple_store_iter_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let k = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let s1 = k.open_single("store_1", StoreOptions::create()).expect("opened");
+        let s2 = k.open_single("store_2", StoreOptions::create()).expect("opened");
+
+        let mut writer = k.write().expect("writer");
+        // Write to "s1"
+        s1.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+        s1.put(&mut writer, "noo", &Value::F64(1234.0.into())).expect("wrote");
+        s1.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+        s1.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+        s1.put(&mut writer, "héllò, töűrîst", &Value::Str("Emil.RuleZ!")).expect("wrote");
+        s1.put(&mut writer, "你好，遊客", &Value::Str("米克規則")).expect("wrote");
+        // &mut writer to "s2"
+        s2.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+        s2.put(&mut writer, "noo", &Value::F64(1234.0.into())).expect("wrote");
+        s2.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+        s2.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+        s2.put(&mut writer, "héllò, töűrîst", &Value::Str("Emil.RuleZ!")).expect("wrote");
+        s2.put(&mut writer, "你好，遊客", &Value::Str("米克規則")).expect("wrote");
+        writer.commit().expect("committed");
+
+        let reader = k.read().unwrap();
+
+        // Iterate through the whole store in "s1"
+        let mut iter = s1.iter_start(&reader).unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "bar");
+        assert_eq!(val, Some(Value::Bool(true)));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "baz");
+        assert_eq!(val, Some(Value::Str("héllo, yöu")));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "foo");
+        assert_eq!(val, Some(Value::I64(1234)));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "héllò, töűrîst");
+        assert_eq!(val, Some(Value::Str("Emil.RuleZ!")));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+
+        // Iterate through the whole store in "s2"
+        let mut iter = s2.iter_start(&reader).unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "bar");
+        assert_eq!(val, Some(Value::Bool(true)));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "baz");
+        assert_eq!(val, Some(Value::Str("héllo, yöu")));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "foo");
+        assert_eq!(val, Some(Value::I64(1234)));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "héllò, töűrîst");
+        assert_eq!(val, Some(Value::Str("Emil.RuleZ!")));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+
+        // Iterate from a given key in "s1"
+        let mut iter = s1.iter_from(&reader, "moo").unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+
+        // Iterate from a given key in "s2"
+        let mut iter = s2.iter_from(&reader, "moo").unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+
+        // Iterate from a given prefix in "s1"
+        let mut iter = s1.iter_from(&reader, "no").unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+
+        // Iterate from a given prefix in "s2"
+        let mut iter = s2.iter_from(&reader, "no").unwrap();
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "noo");
+        assert_eq!(val, Some(Value::F64(1234.0.into())));
+        let (key, val) = iter.next().unwrap().unwrap();
+        assert_eq!(str::from_utf8(key).expect("key"), "你好，遊客");
+        assert_eq!(val, Some(Value::Str("米克規則")));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_store_multiple_thread_safe() {
+        let root = Builder::new().prefix("test_multiple_thread_safe").tempdir().expect("tempdir");
+        fs::create_dir_all(root.path()).expect("dir created");
+
+        let rkv_arc = Arc::new(RwLock::new(Rkv::new::<SafeMode>(root.path()).expect("new succeeded")));
+        let store = rkv_arc.read().unwrap().open_single("test", StoreOptions::create()).expect("opened");
+
+        let num_threads = 10;
+        let mut write_handles = Vec::with_capacity(num_threads as usize);
+        let mut read_handles = Vec::with_capacity(num_threads as usize);
+
+        // Note that this isn't intended to demonstrate a good use of threads.
+        // For this shape of data, it would be more performant to write/read
+        // all values using one transaction in a single thread. The point here
+        // is just to confirm that a store can be shared by multiple threads.
+
+        // For each KV pair, spawn a thread that writes it to the store.
+        for i in 0..num_threads {
+            let rkv_arc = rkv_arc.clone();
+            write_handles.push(thread::spawn(move || {
+                let rkv = rkv_arc.write().expect("rkv");
+                let mut writer = rkv.write().expect("writer");
+                store.put(&mut writer, i.to_string(), &Value::U64(i)).expect("written");
+                writer.commit().unwrap();
+            }));
+        }
+        for handle in write_handles {
+            handle.join().expect("joined");
+        }
+
+        // For each KV pair, spawn a thread that reads it from the store
+        // and returns its value.
+        for i in 0..num_threads {
+            let rkv_arc = rkv_arc.clone();
+            read_handles.push(thread::spawn(move || {
+                let rkv = rkv_arc.read().expect("rkv");
+                let reader = rkv.read().expect("reader");
+                let value = match store.get(&reader, i.to_string()) {
+                    Ok(Some(Value::U64(value))) => value,
+                    Ok(Some(_)) => panic!("value type unexpected"),
+                    Ok(None) => panic!("value not found"),
+                    Err(err) => panic!(err),
+                };
+                assert_eq!(value, i);
+                value
+            }));
+        }
+
+        // Sum the values returned from the threads and confirm that they're
+        // equal to the sum of values written to the threads.
+        let thread_sum: u64 = read_handles.into_iter().map(|handle| handle.join().expect("value")).sum();
+        assert_eq!(thread_sum, (0..num_threads).sum());
+    }
+
+    #[test]
+    fn test_use_value_as_key_safe() {
+        let root = Builder::new().prefix("test_use_value_as_key_safe").tempdir().expect("tempdir");
+        let rkv = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
         let store = rkv.open_single("store", StoreOptions::create()).expect("opened");
 
         {

--- a/src/env.rs
+++ b/src/env.rs
@@ -23,6 +23,7 @@ use crate::backend::{
     BackendRwCursorTransaction,
     BackendStat,
     DatabaseFlags,
+    SafeModeError,
 };
 use crate::error::StoreError;
 use crate::readwrite::{
@@ -175,11 +176,13 @@ where
         if opts.create {
             self.env.create_db(name.into(), opts.flags).map_err(|e| match e.into() {
                 StoreError::LmdbError(lmdb::Error::BadRslot) => StoreError::open_during_transaction(),
+                StoreError::SafeModeError(SafeModeError::DbsIllegalOpen) => StoreError::open_during_transaction(),
                 e => e,
             })
         } else {
             self.env.open_db(name.into()).map_err(|e| match e.into() {
                 StoreError::LmdbError(lmdb::Error::BadRslot) => StoreError::open_during_transaction(),
+                StoreError::SafeModeError(SafeModeError::DbsIllegalOpen) => StoreError::open_during_transaction(),
                 e => e,
             })
         }


### PR DESCRIPTION
I've identified 3 additional situations where our safe mode backend implementation doesn't match LMDB's behavior, fixed in the following 3 individual commits.