### PR TITLE
Fix cursor/iterator lifetime coupling which can result in referencing invalid memory when eliminating dead code

### DIFF
--- a/src/backend/impl_safe/cursor.rs
+++ b/src/backend/impl_safe/cursor.rs
@@ -20,11 +20,11 @@ pub struct RoCursorImpl<'env>(pub(crate) &'env Snapshot);
 impl<'env> BackendRoCursor<'env> for RoCursorImpl<'env> {
     type Iter = IterImpl<'env>;
 
-    fn iter(&mut self) -> Self::Iter {
+    fn into_iter(self) -> Self::Iter {
         IterImpl(Box::new(self.0.iter()))
     }
 
-    fn iter_from<K>(&mut self, key: K) -> Self::Iter
+    fn into_iter_from<K>(self, key: K) -> Self::Iter
     where
         K: AsRef<[u8]>,
     {
@@ -33,7 +33,7 @@ impl<'env> BackendRoCursor<'env> for RoCursorImpl<'env> {
         IterImpl(Box::new(self.0.iter().skip_while(move |&(k, _)| k < key.as_slice())))
     }
 
-    fn iter_dup_of<K>(&mut self, key: K) -> Self::Iter
+    fn into_iter_dup_of<K>(self, key: K) -> Self::Iter
     where
         K: AsRef<[u8]>,
     {
@@ -49,18 +49,18 @@ pub struct RwCursorImpl<'env>(&'env mut Snapshot);
 impl<'env> BackendRoCursor<'env> for RwCursorImpl<'env> {
     type Iter = IterImpl<'env>;
 
-    fn iter(&mut self) -> Self::Iter {
+    fn into_iter(self) -> Self::Iter {
         unimplemented!()
     }
 
-    fn iter_from<K>(&mut self, _key: K) -> Self::Iter
+    fn into_iter_from<K>(self, _key: K) -> Self::Iter
     where
         K: AsRef<[u8]>,
     {
         unimplemented!()
     }
 
-    fn iter_dup_of<K>(&mut self, _key: K) -> Self::Iter
+    fn into_iter_dup_of<K>(self, _key: K) -> Self::Iter
     where
         K: AsRef<[u8]>,
     {

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -161,13 +161,13 @@ pub trait BackendRwCursorTransaction<'env>: BackendRwTransaction {
 pub trait BackendRoCursor<'env>: Debug {
     type Iter: BackendIter<'env>;
 
-    fn iter(&mut self) -> Self::Iter;
+    fn into_iter(self) -> Self::Iter;
 
-    fn iter_from<K>(&mut self, key: K) -> Self::Iter
+    fn into_iter_from<K>(self, key: K) -> Self::Iter
     where
         K: AsRef<[u8]>;
 
-    fn iter_dup_of<K>(&mut self, key: K) -> Self::Iter
+    fn into_iter_dup_of<K>(self, key: K) -> Self::Iter
     where
         K: AsRef<[u8]>;
 }

--- a/src/store/integermulti.rs
+++ b/src/store/integermulti.rs
@@ -51,7 +51,7 @@ where
         }
     }
 
-    pub fn get<'env, R, I, C>(&self, reader: &'env R, k: K) -> Result<Iter<'env, I, C>, StoreError>
+    pub fn get<'env, R, I, C>(&self, reader: &'env R, k: K) -> Result<Iter<'env, I>, StoreError>
     where
         R: Readable<'env, Database = D, RoCursor = C>,
         I: BackendIter<'env>,


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

LMDB semantics dictate that a cursor must be valid for calls to `mdb_cursor_get`. In case of the rust wrappers, this means that the `lmdb::RoCursor`/`lmdb::RwCursor` must be valid the entire lifetime of an `lmdb::Iter`. In other words, cursors must not be dropped while an iterator built from it is alive. Unfortunately, the LMDB crate API does not express this through the type system at all, so we must enforce it somehow.

Before this PR, this worked because dead code wasn't eliminated. The `Iter` types for single/multi database wrappers owned a `C` generic type implementing `BackendRoCursor`, even though they didn't have to.

In case of a safe mode backend, this isn't required, and eliminating the dead code doesn't result in any SIGSEGV. However, in case of an LMDB backend, doing so results in `signal: 11, SIGSEGV: invalid memory reference` when running tests, even though everything compiles successfully and there's no unsafe code used.

These LMDB specifics shouldn't be expressed at this level, since they impose restrictions on other backends (namely safe mode). Ideally, they should be expressed in the LMDB crate (which, as it stands, allows a plethora of unsafe ways of using its API, without them being marked as such through the type system). However, if we don't want to fix the LMDB crate actually expose a safer API, we can do this at the backend level in the RKV crate.

With this PR:
* Since cursors always open just one iterator, this is expressed through the type system now, which simplifies things a bit.
* Safe mode is slightly better optimized memory wise, since a "cursor" is a misnomer in this particular case, and these types can be now dropped safely.