### PR TITLE
Don't allocate when creating 'from' and 'dup_of' iterators

### DIFF
--- a/src/backend/impl_lmdb/cursor.rs
+++ b/src/backend/impl_lmdb/cursor.rs
@@ -30,14 +30,14 @@ impl<'c> BackendRoCursor<'c> for RoCursorImpl<'c> {
 
     fn into_iter_from<K>(self, key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'c,
     {
         IterImpl::new(self.0, |cursor| cursor.iter_from(key))
     }
 
     fn into_iter_dup_of<K>(self, key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'c,
     {
         IterImpl::new(self.0, |cursor| cursor.iter_dup_of(key))
     }
@@ -55,14 +55,14 @@ impl<'c> BackendRoCursor<'c> for RwCursorImpl<'c> {
 
     fn into_iter_from<K>(self, key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'c,
     {
         IterImpl::new(self.0, |cursor| cursor.iter_from(key))
     }
 
     fn into_iter_dup_of<K>(self, key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'c,
     {
         IterImpl::new(self.0, |cursor| cursor.iter_dup_of(key))
     }

--- a/src/backend/impl_safe/cursor.rs
+++ b/src/backend/impl_safe/cursor.rs
@@ -26,20 +26,16 @@ impl<'c> BackendRoCursor<'c> for RoCursorImpl<'c> {
 
     fn into_iter_from<K>(self, key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'c,
     {
-        // FIXME: Don't allocate.
-        let key = key.as_ref().to_vec();
-        IterImpl(Box::new(self.0.iter().skip_while(move |&(k, _)| k < key.as_slice())))
+        IterImpl(Box::new(self.0.iter().skip_while(move |&(k, _)| k < key.as_ref())))
     }
 
     fn into_iter_dup_of<K>(self, key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'c,
     {
-        // FIXME: Don't allocate.
-        let key = key.as_ref().to_vec();
-        IterImpl(Box::new(self.0.iter().filter(move |&(k, _)| k == key.as_slice())))
+        IterImpl(Box::new(self.0.iter().filter(move |&(k, _)| k == key.as_ref())))
     }
 }
 
@@ -55,14 +51,14 @@ impl<'c> BackendRoCursor<'c> for RwCursorImpl<'c> {
 
     fn into_iter_from<K>(self, _key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'c,
     {
         unimplemented!()
     }
 
     fn into_iter_dup_of<K>(self, _key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'c,
     {
         unimplemented!()
     }

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -165,11 +165,11 @@ pub trait BackendRoCursor<'c>: Debug {
 
     fn into_iter_from<K>(self, key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>;
+        K: AsRef<[u8]> + 'c;
 
     fn into_iter_dup_of<K>(self, key: K) -> Self::Iter
     where
-        K: AsRef<[u8]>;
+        K: AsRef<[u8]> + 'c;
 }
 
 pub trait BackendIter<'i> {

--- a/src/store/integermulti.rs
+++ b/src/store/integermulti.rs
@@ -56,6 +56,7 @@ where
         R: Readable<'r, Database = D, RoCursor = C>,
         I: BackendIter<'r>,
         C: BackendRoCursor<'r, Iter = I>,
+        K: 'r,
     {
         self.inner.get(reader, Key::new(&k)?)
     }

--- a/src/store/multi.rs
+++ b/src/store/multi.rs
@@ -53,7 +53,7 @@ where
         R: Readable<'r, Database = D, RoCursor = C>,
         I: BackendIter<'r>,
         C: BackendRoCursor<'r, Iter = I>,
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'r,
     {
         let cursor = reader.open_ro_cursor(&self.db)?;
         let iter = cursor.into_iter_dup_of(k);

--- a/src/store/single.rs
+++ b/src/store/single.rs
@@ -102,7 +102,7 @@ where
         R: Readable<'r, Database = D, RoCursor = C>,
         I: BackendIter<'r>,
         C: BackendRoCursor<'r, Iter = I>,
-        K: AsRef<[u8]>,
+        K: AsRef<[u8]> + 'r,
     {
         let cursor = reader.open_ro_cursor(&self.db)?;
         let iter = cursor.into_iter_from(k);

--- a/tests/test_txn.rs
+++ b/tests/test_txn.rs
@@ -90,7 +90,7 @@ fn read_many() {
     }
 }
 
-fn get_ids_by_field<'t, T>(txn: &'t T, store: MultiStore, field: &str) -> Vec<u64>
+fn get_ids_by_field<'t, T>(txn: &'t T, store: MultiStore, field: &'t str) -> Vec<u64>
 where
     T: Readable<'t, Database = LmdbDatabase, RoCursor = LmdbRoCursor<'t>>,
 {


### PR DESCRIPTION
We're reallocating keys when creating 'from' and 'dup_of' iterators. In practice, this isn't necessary as long as we require keys to live at least as long as the iterators themselves, which is always going to be true.

This PR adds a lifetime constraint for those situations, removing the need for a reallocation.

Signed-off-by: Victor Porof <victor.porof@gmail.com>