### PR TITLE
Delay short-circuiting `skip_while` and `filter` adaptors for better perforamnce in case of multi databases

### DIFF
--- a/src/backend/impl_safe/snapshot.rs
+++ b/src/backend/impl_safe/snapshot.rs
@@ -104,8 +104,8 @@ impl Snapshot {
         }
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&[u8], &[u8])> {
-        self.map.iter().flat_map(|(key, values)| values.iter().map(move |value| (key.as_ref(), value.as_ref())))
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&[u8], impl Iterator<Item = &[u8]>)> {
+        self.map.iter().map(|(key, values)| (key.as_ref(), values.iter().map(|value| value.as_ref())))
     }
 }
 


### PR DESCRIPTION
When generating iterators for multi databases, the (key, value**s**) iterator generated by a snapshot is first flattened into (key, value) iterator; then, this iterator is transformed with `skip_while` and `filter` adaptors.

This approach can be less performant in a situation where a key can contain multiple values. In these situations, these adaptors do extra work because the flattening happens beforehand. Ideally, flattening should happen afterwards, which this PR implements.

Signed-off-by: Victor Porof <victor.porof@gmail.com>