### PR TITLE
Make backend-related documentation easier to understand

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -20,14 +20,44 @@ pub use impl_lmdb::DatabaseImpl as LmdbDatabase;
 pub use impl_lmdb::EnvironmentBuilderImpl as Lmdb;
 pub use impl_lmdb::EnvironmentImpl as LmdbEnvironment;
 pub use impl_lmdb::ErrorImpl as LmdbError;
-pub use impl_lmdb::RoCursorImpl as LmdbRoCursor;
-pub use impl_lmdb::RoTransactionImpl as LmdbRoTransaction;
-pub use impl_lmdb::RwTransactionImpl as LmdbRwTransaction;
+pub use impl_lmdb::IterImpl as LmdbIter;
+pub use impl_lmdb::{
+    DatabaseFlagsImpl as LmdbDatabaseFlags,
+    EnvironmentFlagsImpl as LmdbEnvironmentFlags,
+    WriteFlagsImpl as LmdbWriteFlags,
+};
+pub use impl_lmdb::{
+    InfoImpl as LmdbInfo,
+    StatImpl as LmdbStat,
+};
+pub use impl_lmdb::{
+    RoCursorImpl as LmdbRoCursor,
+    RwCursorImpl as LmdbRwCursor,
+};
+pub use impl_lmdb::{
+    RoTransactionImpl as LmdbRoTransaction,
+    RwTransactionImpl as LmdbRwTransaction,
+};
 
 pub use impl_safe::DatabaseImpl as SafeModeDatabase;
 pub use impl_safe::EnvironmentBuilderImpl as SafeMode;
 pub use impl_safe::EnvironmentImpl as SafeModeEnvironment;
 pub use impl_safe::ErrorImpl as SafeModeError;
-pub use impl_safe::RoCursorImpl as SafeModeRoCursor;
-pub use impl_safe::RoTransactionImpl as SafeModeRoTransaction;
-pub use impl_safe::RwTransactionImpl as SafeModeRwTransaction;
+pub use impl_safe::IterImpl as SafeModeIter;
+pub use impl_safe::{
+    DatabaseFlagsImpl as SafeModeDatabaseFlags,
+    EnvironmentFlagsImpl as SafeModeEnvironmentFlags,
+    WriteFlagsImpl as SafeModeWriteFlags,
+};
+pub use impl_safe::{
+    InfoImpl as SafeModeInfo,
+    StatImpl as SafeModeStat,
+};
+pub use impl_safe::{
+    RoCursorImpl as SafeModeRoCursor,
+    RwCursorImpl as SafeModeRwCursor,
+};
+pub use impl_safe::{
+    RoTransactionImpl as SafeModeRoTransaction,
+    RwTransactionImpl as SafeModeRwTransaction,
+};

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -24,7 +24,7 @@ pub use impl_lmdb::RoCursorImpl as LmdbRoCursor;
 pub use impl_lmdb::RoTransactionImpl as LmdbRoTransaction;
 pub use impl_lmdb::RwTransactionImpl as LmdbRwTransaction;
 
-pub use impl_safe::DatabaseId as SafeModeDatabase;
+pub use impl_safe::DatabaseImpl as SafeModeDatabase;
 pub use impl_safe::EnvironmentBuilderImpl as SafeMode;
 pub use impl_safe::EnvironmentImpl as SafeModeEnvironment;
 pub use impl_safe::ErrorImpl as SafeModeError;

--- a/src/backend/impl_safe.rs
+++ b/src/backend/impl_safe.rs
@@ -23,7 +23,7 @@ pub use cursor::{
     RoCursorImpl,
     RwCursorImpl,
 };
-pub use database::DatabaseId;
+pub use database::DatabaseImpl;
 pub use environment::{
     EnvironmentBuilderImpl,
     EnvironmentImpl,

--- a/src/backend/impl_safe/database.rs
+++ b/src/backend/impl_safe/database.rs
@@ -18,18 +18,19 @@ use super::snapshot::Snapshot;
 use super::DatabaseFlagsImpl;
 use crate::backend::traits::BackendDatabase;
 
-pub type DatabaseId = Id<DatabaseImpl>;
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+pub struct DatabaseImpl(pub(crate) Id<Database>);
 
-impl BackendDatabase for DatabaseId {}
+impl BackendDatabase for DatabaseImpl {}
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct DatabaseImpl {
+pub struct Database {
     snapshot: Snapshot,
 }
 
-impl DatabaseImpl {
-    pub(crate) fn new(flags: Option<DatabaseFlagsImpl>, snapshot: Option<Snapshot>) -> DatabaseImpl {
-        DatabaseImpl {
+impl Database {
+    pub(crate) fn new(flags: Option<DatabaseFlagsImpl>, snapshot: Option<Snapshot>) -> Database {
+        Database {
             snapshot: snapshot.unwrap_or_else(|| Snapshot::new(flags)),
         }
     }


### PR DESCRIPTION
When updating the crate documentation, I noticed that our exports can be confusing when trying to understand how backends work. Ideally, they should be symmetric in terms of exports.

This PR makes it so.