### PR TITLE
Error ergonomics

### DIFF
--- a/src/backend/impl_lmdb/error.rs
+++ b/src/backend/impl_lmdb/error.rs
@@ -28,7 +28,7 @@ impl Into<StoreError> for ErrorImpl {
     fn into(self) -> StoreError {
         match self.0 {
             lmdb::Error::NotFound => StoreError::KeyValuePairNotFound,
-            lmdb::Error::Invalid => StoreError::DatabaseInvalid,
+            lmdb::Error::Invalid => StoreError::FileInvalid,
             _ => StoreError::LmdbError(self.0),
         }
     }

--- a/src/backend/impl_lmdb/error.rs
+++ b/src/backend/impl_lmdb/error.rs
@@ -28,7 +28,11 @@ impl Into<StoreError> for ErrorImpl {
     fn into(self) -> StoreError {
         match self.0 {
             lmdb::Error::NotFound => StoreError::KeyValuePairNotFound,
+            lmdb::Error::BadValSize => StoreError::KeyValuePairBadSize,
             lmdb::Error::Invalid => StoreError::FileInvalid,
+            lmdb::Error::MapFull => StoreError::MapFull,
+            lmdb::Error::DbsFull => StoreError::DbsFull,
+            lmdb::Error::ReadersFull => StoreError::ReadersFull,
             _ => StoreError::LmdbError(self.0),
         }
     }

--- a/src/backend/impl_safe/environment.rs
+++ b/src/backend/impl_safe/environment.rs
@@ -110,8 +110,8 @@ pub struct EnvironmentImpl {
 
 impl EnvironmentImpl {
     fn serialize(&self) -> Result<Vec<u8>, ErrorImpl> {
-        let arena = self.arena.read().map_err(|_| ErrorImpl::DbPoisonError)?;
-        let dbs = self.dbs.read().map_err(|_| ErrorImpl::DbPoisonError)?;
+        let arena = self.arena.read().map_err(|_| ErrorImpl::EnvPoisonError)?;
+        let dbs = self.dbs.read().map_err(|_| ErrorImpl::EnvPoisonError)?;
         let data: HashMap<_, _> = dbs.iter().map(|(name, id)| (name, &arena[id.0])).collect();
         Ok(bincode::serialize(&data)?)
     }
@@ -179,11 +179,11 @@ impl EnvironmentImpl {
     }
 
     pub(crate) fn dbs(&self) -> Result<RwLockReadGuard<DatabaseArena>, ErrorImpl> {
-        self.arena.read().map_err(|_| ErrorImpl::DbPoisonError)
+        self.arena.read().map_err(|_| ErrorImpl::EnvPoisonError)
     }
 
     pub(crate) fn dbs_mut(&self) -> Result<RwLockWriteGuard<DatabaseArena>, ErrorImpl> {
-        self.arena.write().map_err(|_| ErrorImpl::DbPoisonError)
+        self.arena.write().map_err(|_| ErrorImpl::EnvPoisonError)
     }
 }
 
@@ -202,7 +202,7 @@ impl<'e> BackendEnvironment<'e> for EnvironmentImpl {
         }
         // TOOD: don't reallocate `name`.
         let key = name.map(String::from);
-        let dbs = self.dbs.read().map_err(|_| ErrorImpl::DbPoisonError)?;
+        let dbs = self.dbs.read().map_err(|_| ErrorImpl::EnvPoisonError)?;
         let id = dbs.get(&key).ok_or(ErrorImpl::DbNotFoundError)?;
         Ok(*id)
     }
@@ -213,8 +213,8 @@ impl<'e> BackendEnvironment<'e> for EnvironmentImpl {
         }
         // TOOD: don't reallocate `name`.
         let key = name.map(String::from);
-        let mut dbs = self.dbs.write().map_err(|_| ErrorImpl::DbPoisonError)?;
-        let mut arena = self.arena.write().map_err(|_| ErrorImpl::DbPoisonError)?;
+        let mut dbs = self.dbs.write().map_err(|_| ErrorImpl::EnvPoisonError)?;
+        let mut arena = self.arena.write().map_err(|_| ErrorImpl::EnvPoisonError)?;
         if dbs.keys().filter_map(|k| k.as_ref()).count() >= self.max_dbs {
             return Err(ErrorImpl::DbsFull);
         }

--- a/src/backend/impl_safe/error.rs
+++ b/src/backend/impl_safe/error.rs
@@ -47,9 +47,14 @@ impl fmt::Display for ErrorImpl {
 
 impl Into<StoreError> for ErrorImpl {
     fn into(self) -> StoreError {
+        // The `StoreError::KeyValuePairBadSize` error is unused, because this
+        // backend supports keys and values of arbitrary sizes.
+        // The `StoreError::MapFull` and `StoreError::ReadersFull` are
+        // unimplemented yet, but they should be in the future.
         match self {
             ErrorImpl::KeyValuePairNotFound => StoreError::KeyValuePairNotFound,
             ErrorImpl::BincodeError(_) => StoreError::FileInvalid,
+            ErrorImpl::DbsFull => StoreError::DbsFull,
             _ => StoreError::SafeModeError(self),
         }
     }

--- a/src/backend/impl_safe/error.rs
+++ b/src/backend/impl_safe/error.rs
@@ -19,7 +19,7 @@ use crate::error::StoreError;
 #[derive(Debug)]
 pub enum ErrorImpl {
     KeyValuePairNotFound,
-    DbPoisonError,
+    EnvPoisonError,
     DbsFull,
     DbsIllegalOpen,
     DbNotFoundError,
@@ -34,7 +34,7 @@ impl fmt::Display for ErrorImpl {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ErrorImpl::KeyValuePairNotFound => write!(fmt, "KeyValuePairNotFound (safe mode)"),
-            ErrorImpl::DbPoisonError => write!(fmt, "DbPoisonError (safe mode)"),
+            ErrorImpl::EnvPoisonError => write!(fmt, "EnvPoisonError (safe mode)"),
             ErrorImpl::DbsFull => write!(fmt, "DbsFull (safe mode)"),
             ErrorImpl::DbsIllegalOpen => write!(fmt, "DbIllegalOpen (safe mode)"),
             ErrorImpl::DbNotFoundError => write!(fmt, "DbNotFoundError (safe mode)"),

--- a/src/backend/impl_safe/error.rs
+++ b/src/backend/impl_safe/error.rs
@@ -49,7 +49,7 @@ impl Into<StoreError> for ErrorImpl {
     fn into(self) -> StoreError {
         match self {
             ErrorImpl::KeyValuePairNotFound => StoreError::KeyValuePairNotFound,
-            ErrorImpl::BincodeError(_) => StoreError::DatabaseInvalid,
+            ErrorImpl::BincodeError(_) => StoreError::FileInvalid,
             _ => StoreError::SafeModeError(self),
         }
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "opened: LmdbError(DbsFull)")]
+    #[should_panic(expected = "opened: DbsFull")]
     fn test_open_with_capacity() {
         let root = Builder::new().prefix("test_open_with_capacity").tempdir().expect("tempdir");
         println!("Root path: {:?}", root.path());
@@ -441,7 +441,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "wrote: LmdbError(MapFull)")]
+    #[should_panic(expected = "wrote: MapFull")]
     fn test_exceed_map_size() {
         let root = Builder::new().prefix("test_exceed_map_size").tempdir().expect("tempdir");
         println!("Root path: {:?}", root.path());
@@ -459,7 +459,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "wrote: LmdbError(BadValSize)")]
+    #[should_panic(expected = "wrote: KeyValuePairBadSize")]
     fn test_exceed_key_size_limit() {
         let root = Builder::new().prefix("test_exceed_key_size_limit").tempdir().expect("tempdir");
         println!("Root path: {:?}", root.path());
@@ -1530,7 +1530,7 @@ mod tests_safe {
     }
 
     #[test]
-    #[should_panic(expected = "opened: SafeModeError(DbsFull)")]
+    #[should_panic(expected = "opened: DbsFull")]
     fn test_open_with_capacity_safe() {
         let root = Builder::new().prefix("test_open_with_capacity").tempdir().expect("tempdir");
         println!("Root path: {:?}", root.path());

--- a/src/env.rs
+++ b/src/env.rs
@@ -748,7 +748,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "new failed: DatabaseInvalid")]
+    #[should_panic(expected = "new failed: FileInvalid")]
     fn test_open_a_broken_store() {
         let root = Builder::new().prefix("test_open_a_missing_store").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");
@@ -1793,7 +1793,7 @@ mod tests_safe {
     }
 
     #[test]
-    #[should_panic(expected = "new failed: DatabaseInvalid")]
+    #[should_panic(expected = "new failed: FileInvalid")]
     fn test_open_a_broken_store_safe() {
         let root = Builder::new().prefix("test_open_a_missing_store_safe").tempdir().expect("tempdir");
         fs::create_dir_all(root.path()).expect("dir created");

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,8 +61,20 @@ pub enum StoreError {
     #[fail(display = "key/value pair not found")]
     KeyValuePairNotFound,
 
+    #[fail(display = "unsupported size of key/DB name/data")]
+    KeyValuePairBadSize,
+
     #[fail(display = "file is not a valid database")]
     FileInvalid,
+
+    #[fail(display = "environment mapsize reached")]
+    MapFull,
+
+    #[fail(display = "environment maxdbs reached")]
+    DbsFull,
+
+    #[fail(display = "environment maxreaders reached")]
+    ReadersFull,
 
     #[fail(display = "I/O error: {:?}", _0)]
     IoError(io::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,11 +58,11 @@ pub enum StoreError {
     #[fail(display = "database corrupted")]
     DatabaseCorrupted,
 
-    #[fail(display = "database invalid")]
-    DatabaseInvalid,
-
     #[fail(display = "key/value pair not found")]
     KeyValuePairNotFound,
+
+    #[fail(display = "file is not a valid database")]
+    FileInvalid,
 
     #[fail(display = "I/O error: {:?}", _0)]
     IoError(io::Error),


### PR DESCRIPTION
When updating kvstore to use RKV in safe mode [bug 1597898](https://bugzilla.mozilla.org/show_bug.cgi?id=1597898), I noticed that more LMDB-related errors were used at the top-level.

Ideally, common backend errors should be exposed as top-level store errors. This allows consumers not have to worry about which backend they're using when handling various errors in general.

For example, In case of CRLite, this was just KeyValuePairNotFound. It's better to have this a top-level store error, because otherwise consumers would have to guard for both the LMDB and SafeMode variants of this error. And if they switch to a third backend in the future, they'd have to remember to add a third guard everywhere. A similar story is in case of kvstore.

Obviously, we shouldn't do this for clearly backend-specific errors which won't be shared across potential future backends.