### PR TITLE
Make migration easier for consumers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ lazy_static = "1.0"
 lmdb-rkv = "0.14"
 log = "0.4"
 ordered-float = "1.0"
+paste = "0.1"
 serde = {version = "1.0", features = ["derive", "rc"]}
 serde_derive = "1.0"
 url = "2.0"

--- a/src/backend/impl_lmdb/environment.rs
+++ b/src/backend/impl_lmdb/environment.rs
@@ -43,7 +43,6 @@ pub struct EnvironmentBuilderImpl {
     builder: lmdb::EnvironmentBuilder,
     envtype: EnvironmentType,
     make_dir: bool,
-    check_env_exists: bool,
 }
 
 impl<'b> BackendEnvironmentBuilder<'b> for EnvironmentBuilderImpl {
@@ -56,7 +55,6 @@ impl<'b> BackendEnvironmentBuilder<'b> for EnvironmentBuilderImpl {
             builder: lmdb::Environment::new(),
             envtype: EnvironmentType::SingleDatabase,
             make_dir: false,
-            check_env_exists: false,
         }
     }
 
@@ -91,15 +89,7 @@ impl<'b> BackendEnvironmentBuilder<'b> for EnvironmentBuilderImpl {
         self
     }
 
-    fn set_check_if_env_exists(&mut self, check_env_exists: bool) -> &mut Self {
-        self.check_env_exists = check_env_exists;
-        self
-    }
-
     fn open(&self, path: &Path) -> Result<Self::Environment, Self::Error> {
-        if self.check_env_exists && !path.join("data.mdb").exists() {
-            return Err(ErrorImpl::EnvironmentDoesNotExistError(path.into()));
-        }
         if !path.is_dir() {
             if !self.make_dir {
                 return Err(ErrorImpl::DirectoryDoesNotExistError(path.into()));

--- a/src/backend/impl_lmdb/error.rs
+++ b/src/backend/impl_lmdb/error.rs
@@ -23,7 +23,6 @@ use crate::{
 pub enum ErrorImpl {
     LmdbError(lmdb::Error),
     DirectoryDoesNotExistError(PathBuf),
-    EnvironmentDoesNotExistError(PathBuf),
     IoError(io::Error),
 }
 
@@ -34,7 +33,6 @@ impl fmt::Display for ErrorImpl {
         match self {
             ErrorImpl::LmdbError(e) => e.fmt(fmt),
             ErrorImpl::DirectoryDoesNotExistError(_) => write!(fmt, "DirectoryDoesNotExistError"),
-            ErrorImpl::EnvironmentDoesNotExistError(_) => write!(fmt, "EnvironmentDoesNotExistError"),
             ErrorImpl::IoError(e) => e.fmt(fmt),
         }
     }
@@ -52,7 +50,6 @@ impl Into<StoreError> for ErrorImpl {
             ErrorImpl::LmdbError(lmdb::Error::ReadersFull) => StoreError::ReadersFull,
             ErrorImpl::LmdbError(error) => StoreError::LmdbError(error),
             ErrorImpl::DirectoryDoesNotExistError(path) => StoreError::DirectoryDoesNotExistError(path),
-            ErrorImpl::EnvironmentDoesNotExistError(path) => StoreError::EnvironmentDoesNotExistError(path),
             ErrorImpl::IoError(error) => StoreError::IoError(error),
         }
     }

--- a/src/backend/impl_lmdb/error.rs
+++ b/src/backend/impl_lmdb/error.rs
@@ -22,7 +22,7 @@ use crate::{
 #[derive(Debug)]
 pub enum ErrorImpl {
     LmdbError(lmdb::Error),
-    DirectoryDoesNotExistError(PathBuf),
+    UnsuitableEnvironmentPath(PathBuf),
     IoError(io::Error),
 }
 
@@ -32,7 +32,7 @@ impl fmt::Display for ErrorImpl {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ErrorImpl::LmdbError(e) => e.fmt(fmt),
-            ErrorImpl::DirectoryDoesNotExistError(_) => write!(fmt, "DirectoryDoesNotExistError"),
+            ErrorImpl::UnsuitableEnvironmentPath(_) => write!(fmt, "UnsuitableEnvironmentPath"),
             ErrorImpl::IoError(e) => e.fmt(fmt),
         }
     }
@@ -49,8 +49,14 @@ impl Into<StoreError> for ErrorImpl {
             ErrorImpl::LmdbError(lmdb::Error::DbsFull) => StoreError::DbsFull,
             ErrorImpl::LmdbError(lmdb::Error::ReadersFull) => StoreError::ReadersFull,
             ErrorImpl::LmdbError(error) => StoreError::LmdbError(error),
-            ErrorImpl::DirectoryDoesNotExistError(path) => StoreError::DirectoryDoesNotExistError(path),
+            ErrorImpl::UnsuitableEnvironmentPath(path) => StoreError::UnsuitableEnvironmentPath(path),
             ErrorImpl::IoError(error) => StoreError::IoError(error),
         }
+    }
+}
+
+impl From<io::Error> for ErrorImpl {
+    fn from(e: io::Error) -> ErrorImpl {
+        ErrorImpl::IoError(e)
     }
 }

--- a/src/backend/impl_safe/environment.rs
+++ b/src/backend/impl_safe/environment.rs
@@ -278,6 +278,8 @@ impl<'e> BackendEnvironment<'e> for EnvironmentImpl {
     }
 
     fn get_files_on_disk(&self) -> Vec<PathBuf> {
+        // Technically NO_SUB_DIR and NO_LOCK should change this output, but
+        // they're both currently unimplemented with this storage backend.
         let mut db_filename = self.path.clone();
         db_filename.push(DEFAULT_DB_FILENAME);
         return vec![db_filename];

--- a/src/backend/impl_safe/environment.rs
+++ b/src/backend/impl_safe/environment.rs
@@ -55,7 +55,6 @@ pub struct EnvironmentBuilderImpl {
     max_dbs: Option<usize>,
     map_size: Option<usize>,
     make_dir: bool,
-    check_env_exists: bool,
 }
 
 impl<'b> BackendEnvironmentBuilder<'b> for EnvironmentBuilderImpl {
@@ -70,7 +69,6 @@ impl<'b> BackendEnvironmentBuilder<'b> for EnvironmentBuilderImpl {
             max_dbs: None,
             map_size: None,
             make_dir: false,
-            check_env_exists: false,
         }
     }
 
@@ -102,15 +100,7 @@ impl<'b> BackendEnvironmentBuilder<'b> for EnvironmentBuilderImpl {
         self
     }
 
-    fn set_check_if_env_exists(&mut self, check_env_exists: bool) -> &mut Self {
-        self.check_env_exists = check_env_exists;
-        self
-    }
-
     fn open(&self, path: &Path) -> Result<Self::Environment, Self::Error> {
-        if self.check_env_exists && !path.join(DEFAULT_DB_FILENAME).exists() {
-            return Err(ErrorImpl::EnvironmentDoesNotExistError(path.into()));
-        }
         if !path.is_dir() {
             if !self.make_dir {
                 return Err(ErrorImpl::DirectoryDoesNotExistError(path.into()));

--- a/src/backend/impl_safe/environment.rs
+++ b/src/backend/impl_safe/environment.rs
@@ -286,4 +286,10 @@ impl<'e> BackendEnvironment<'e> for EnvironmentImpl {
         warn!("`set_map_size({})` is ignored by this storage backend.", size);
         Ok(())
     }
+
+    fn get_files_on_disk(&self) -> Vec<PathBuf> {
+        let mut db_filename = self.path.clone();
+        db_filename.push(DEFAULT_DB_FILENAME);
+        return vec![db_filename];
+    }
 }

--- a/src/backend/impl_safe/environment.rs
+++ b/src/backend/impl_safe/environment.rs
@@ -101,9 +101,11 @@ impl<'b> BackendEnvironmentBuilder<'b> for EnvironmentBuilderImpl {
     }
 
     fn open(&self, path: &Path) -> Result<Self::Environment, Self::Error> {
+        // Technically NO_SUB_DIR should change these checks here, but they're both currently
+        // unimplemented with this storage backend.
         if !path.is_dir() {
             if !self.make_dir {
-                return Err(ErrorImpl::DirectoryDoesNotExistError(path.into()));
+                return Err(ErrorImpl::UnsuitableEnvironmentPath(path.into()));
             }
             fs::create_dir_all(path)?;
         }

--- a/src/backend/impl_safe/error.rs
+++ b/src/backend/impl_safe/error.rs
@@ -30,7 +30,6 @@ pub enum ErrorImpl {
     DbNotFoundError,
     DbIsForeignError,
     DirectoryDoesNotExistError(PathBuf),
-    EnvironmentDoesNotExistError(PathBuf),
     IoError(io::Error),
     BincodeError(BincodeError),
 }
@@ -47,7 +46,6 @@ impl fmt::Display for ErrorImpl {
             ErrorImpl::DbNotFoundError => write!(fmt, "DbNotFoundError (safe mode)"),
             ErrorImpl::DbIsForeignError => write!(fmt, "DbIsForeignError (safe mode)"),
             ErrorImpl::DirectoryDoesNotExistError(_) => write!(fmt, "DirectoryDoesNotExistError (safe mode)"),
-            ErrorImpl::EnvironmentDoesNotExistError(_) => write!(fmt, "EnvironmentDoesNotExistError (safe mode)"),
             ErrorImpl::IoError(e) => e.fmt(fmt),
             ErrorImpl::BincodeError(e) => e.fmt(fmt),
         }
@@ -65,7 +63,6 @@ impl Into<StoreError> for ErrorImpl {
             ErrorImpl::BincodeError(_) => StoreError::FileInvalid,
             ErrorImpl::DbsFull => StoreError::DbsFull,
             ErrorImpl::DirectoryDoesNotExistError(path) => StoreError::DirectoryDoesNotExistError(path),
-            ErrorImpl::EnvironmentDoesNotExistError(path) => StoreError::EnvironmentDoesNotExistError(path),
             ErrorImpl::IoError(error) => StoreError::IoError(error),
             _ => StoreError::SafeModeError(self),
         }

--- a/src/backend/impl_safe/error.rs
+++ b/src/backend/impl_safe/error.rs
@@ -29,7 +29,7 @@ pub enum ErrorImpl {
     DbsIllegalOpen,
     DbNotFoundError,
     DbIsForeignError,
-    DirectoryDoesNotExistError(PathBuf),
+    UnsuitableEnvironmentPath(PathBuf),
     IoError(io::Error),
     BincodeError(BincodeError),
 }
@@ -45,7 +45,7 @@ impl fmt::Display for ErrorImpl {
             ErrorImpl::DbsIllegalOpen => write!(fmt, "DbIllegalOpen (safe mode)"),
             ErrorImpl::DbNotFoundError => write!(fmt, "DbNotFoundError (safe mode)"),
             ErrorImpl::DbIsForeignError => write!(fmt, "DbIsForeignError (safe mode)"),
-            ErrorImpl::DirectoryDoesNotExistError(_) => write!(fmt, "DirectoryDoesNotExistError (safe mode)"),
+            ErrorImpl::UnsuitableEnvironmentPath(_) => write!(fmt, "UnsuitableEnvironmentPath (safe mode)"),
             ErrorImpl::IoError(e) => e.fmt(fmt),
             ErrorImpl::BincodeError(e) => e.fmt(fmt),
         }
@@ -62,7 +62,7 @@ impl Into<StoreError> for ErrorImpl {
             ErrorImpl::KeyValuePairNotFound => StoreError::KeyValuePairNotFound,
             ErrorImpl::BincodeError(_) => StoreError::FileInvalid,
             ErrorImpl::DbsFull => StoreError::DbsFull,
-            ErrorImpl::DirectoryDoesNotExistError(path) => StoreError::DirectoryDoesNotExistError(path),
+            ErrorImpl::UnsuitableEnvironmentPath(path) => StoreError::UnsuitableEnvironmentPath(path),
             ErrorImpl::IoError(error) => StoreError::IoError(error),
             _ => StoreError::SafeModeError(self),
         }

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -13,7 +13,10 @@ use std::{
         Debug,
         Display,
     },
-    path::Path,
+    path::{
+        Path,
+        PathBuf,
+    },
 };
 
 use crate::{
@@ -125,6 +128,8 @@ pub trait BackendEnvironment<'e>: Debug {
     fn load_ratio(&self) -> Result<Option<f32>, Self::Error>;
 
     fn set_map_size(&self, size: usize) -> Result<(), Self::Error>;
+
+    fn get_files_on_disk(&self) -> Vec<PathBuf>;
 }
 
 pub trait BackendRoTransaction: Debug {

--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -93,8 +93,6 @@ pub trait BackendEnvironmentBuilder<'b>: Debug + Eq + PartialEq + Copy + Clone {
 
     fn set_make_dir_if_needed(&mut self, make_dir: bool) -> &mut Self;
 
-    fn set_check_if_env_exists(&mut self, check_env: bool) -> &mut Self;
-
     fn open(&self, path: &Path) -> Result<Self::Environment, Self::Error>;
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -9,6 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 use std::{
+    fs,
     os::raw::c_uint,
     path::{
         Path,
@@ -307,5 +308,19 @@ where
     ///   `LmdbError::MapResized`.
     pub fn set_map_size(&self, size: usize) -> Result<(), StoreError> {
         self.env.set_map_size(size).map_err(Into::into)
+    }
+
+    /// Closes this environment and deletes all its files from disk. Doesn't delete the
+    /// folder used when opening the environment.
+    pub fn close_and_delete(self) -> Result<(), StoreError> {
+        let files = self.env.get_files_on_disk();
+        self.sync(true)?;
+        drop(self);
+
+        for file in files {
+            fs::remove_file(file)?;
+        }
+
+        Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,9 +87,6 @@ pub enum StoreError {
     #[fail(display = "directory does not exist or not a directory: {:?}", _0)]
     DirectoryDoesNotExistError(PathBuf),
 
-    #[fail(display = "environment does not exist in directory: {:?}", _0)]
-    EnvironmentDoesNotExistError(PathBuf),
-
     #[fail(display = "data error: {:?}", _0)]
     DataError(DataError),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,8 +84,8 @@ pub enum StoreError {
     #[fail(display = "I/O error: {:?}", _0)]
     IoError(io::Error),
 
-    #[fail(display = "directory does not exist or not a directory: {:?}", _0)]
-    DirectoryDoesNotExistError(PathBuf),
+    #[fail(display = "environment path does not exist or not the right type: {:?}", _0)]
+    UnsuitableEnvironmentPath(PathBuf),
 
     #[fail(display = "data error: {:?}", _0)]
     DataError(DataError),

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -39,8 +39,8 @@ where
     let canonical = path.into().canonicalize()?;
 
     Ok(if cfg!(target_os = "windows") {
-        let url = Url::from_file_path(&canonical).map_err(|_| io::Error::new(io::ErrorKind::Other, "passing error"))?;
-        url.to_file_path().map_err(|_| io::Error::new(io::ErrorKind::Other, "path canonicalization error"))?
+        let map_err = |_| io::Error::new(io::ErrorKind::Other, "path canonicalization error");
+        Url::from_file_path(&canonical).and_then(|url| url.to_file_path()).map_err(map_err)?
     } else {
         canonical
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,7 @@ pub use error::{
     StoreError,
 };
 pub use manager::Manager;
+pub use migrator::Migrator;
 pub use readwrite::{
     Readable,
     Reader,

--- a/src/migrator.rs
+++ b/src/migrator.rs
@@ -96,16 +96,12 @@ macro_rules! fn_migrator {
             D: std::ops::Deref<Target = Rkv<$dst_env>>,
         {
             use crate::backend::*;
+
             let mut manager = crate::Manager::<$src_env>::singleton().write()?;
             let mut builder = Rkv::<$src_env>::environment_builder::<$builder>();
             builder.set_max_dbs(crate::env::DEFAULT_MAX_DBS);
-            builder.set_check_if_env_exists(true);
             builder = build(builder);
-
-            let src_env = match manager.get_or_create_from_builder(path, builder, Rkv::from_builder::<$builder>) {
-                Err(crate::StoreError::EnvironmentDoesNotExistError(_)) => return Ok(()),
-                result => result,
-            }?;
+            let src_env = manager.get_or_create_from_builder(path, builder, Rkv::from_builder::<$builder>)?;
 
             match Migrator::$migrate(src_env.read()?, dst_env) {
                 Err(crate::MigrateError::SourceEmpty) => return Ok(()),

--- a/src/migrator.rs
+++ b/src/migrator.rs
@@ -47,8 +47,9 @@ pub use crate::backend::{
 };
 
 // FIXME: should parametrize this instead.
+
 macro_rules! fn_migrator {
-    ($name:tt, $src:ty, $dst:ty) => {
+    ($name:tt, $src_env:ty, $dst_env:ty) => {
         /// Migrate all data in all of databases from the source environment to the destination
         /// environment. This includes all key/value pairs in the main database that aren't
         /// metadata about subdatabases and all key/value pairs in all subdatabases.
@@ -57,7 +58,11 @@ macro_rules! fn_migrator {
         /// the given environments.
         ///
         /// The destination environment should be empty of data, otherwise an error is returned.
-        pub fn $name(src_env: &Rkv<$src>, dst_env: &Rkv<$dst>) -> Result<(), MigrateError> {
+        pub fn $name<S, D>(src_env: S, dst_env: D) -> Result<(), MigrateError>
+        where
+            S: std::ops::Deref<Target = Rkv<$src_env>>,
+            D: std::ops::Deref<Target = Rkv<$dst_env>>,
+        {
             let src_dbs = src_env.get_dbs().unwrap();
             if src_dbs.is_empty() {
                 return Err(MigrateError::SourceEmpty);
@@ -80,12 +85,58 @@ macro_rules! fn_migrator {
             Ok(())
         }
     };
+
+    ($migrate:tt, $name:tt, $builder:tt, $src_env:ty, $dst_env:ty) => {
+        /// Same as the other migration methods, but automatically attempts to open the source
+        /// environment, ignores it if it doesn't exist or if it's empty, and finally attempts to
+        /// delete all of its supporting files.
+        pub fn $name<F, D>(path: &std::path::Path, build: F, dst_env: D) -> Result<(), MigrateError>
+        where
+            F: FnOnce(crate::backend::$builder) -> crate::backend::$builder,
+            D: std::ops::Deref<Target = Rkv<$dst_env>>,
+        {
+            use crate::backend::*;
+            let mut manager = crate::Manager::<$src_env>::singleton().write()?;
+            let mut builder = Rkv::<$src_env>::environment_builder::<$builder>();
+            builder.set_max_dbs(crate::env::DEFAULT_MAX_DBS);
+            builder.set_check_if_env_exists(true);
+            builder = build(builder);
+
+            let src_env = match manager.get_or_create_from_builder(path, builder, Rkv::from_builder::<$builder>) {
+                Err(crate::StoreError::EnvironmentDoesNotExistError(_)) => return Ok(()),
+                result => result,
+            }?;
+
+            match Migrator::$migrate(src_env.read()?, dst_env) {
+                Err(crate::MigrateError::SourceEmpty) => return Ok(()),
+                result => result,
+            }?;
+
+            drop(src_env);
+            manager.try_close_and_delete(path)?;
+
+            Ok(())
+        }
+    };
+}
+
+macro_rules! fns_migrator {
+    ($src:tt, $dst:tt) => {
+        paste::item! {
+            fns_migrator!([<migrate_ $src _to_ $dst>], $src, $dst);
+            fns_migrator!([<migrate_ $dst _to_ $src>], $dst, $src);
+        }
+    };
+    ($name:tt, $src:tt, $dst:tt) => {
+        paste::item! {
+            fn_migrator!($name, [<$src:camel Environment>], [<$dst:camel Environment>]);
+            fn_migrator!($name, [<auto_ $name>], [<$src:camel>], [<$src:camel Environment>], [<$dst:camel Environment>]);
+        }
+    };
 }
 
 pub struct Migrator;
 
 impl Migrator {
-    fn_migrator!(migrate_lmdb_to_safe_mode, LmdbEnvironment, SafeModeEnvironment);
-
-    fn_migrator!(migrate_safe_mode_to_lmdb, SafeModeEnvironment, LmdbEnvironment);
+    fns_migrator!(lmdb, safe_mode);
 }

--- a/tests/env-migration.rs
+++ b/tests/env-migration.rs
@@ -14,7 +14,6 @@ use tempfile::Builder;
 
 use rkv::{
     backend::{
-        BackendEnvironmentBuilder,
         Lmdb,
         SafeMode,
     },
@@ -182,16 +181,6 @@ fn test_migrator_round_trip() {
 }
 
 #[test]
-#[should_panic(expected = "new succeeded: EnvironmentDoesNotExistError")]
-fn test_migrator_lmdb_to_safe_0() {
-    let mut builder = Lmdb::new();
-    builder.set_check_if_env_exists(true);
-
-    let root = Builder::new().prefix("test_migrate_lmdb_to_safe").tempdir().expect("tempdir");
-    let _ = Rkv::from_builder::<Lmdb>(root.path(), builder).expect("new succeeded");
-}
-
-#[test]
 #[should_panic(expected = "migrated: SourceEmpty")]
 fn test_migrator_lmdb_to_safe_1() {
     let root = Builder::new().prefix("test_migrate_lmdb_to_safe").tempdir().expect("tempdir");
@@ -230,16 +219,6 @@ fn test_migrator_lmdb_to_safe_3() {
     assert_eq!(store.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
     assert_eq!(store.get(&reader, "bar").expect("read"), Some(Value::Bool(true)));
     assert_eq!(store.get(&reader, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
-}
-
-#[test]
-#[should_panic(expected = "new succeeded: EnvironmentDoesNotExistError")]
-fn test_migrator_safe_to_lmdb_0() {
-    let mut builder = SafeMode::new();
-    builder.set_check_if_env_exists(true);
-
-    let root = Builder::new().prefix("test_migrate_safe_to_lmdb").tempdir().expect("tempdir");
-    let _ = Rkv::from_builder::<SafeMode>(root.path(), builder).expect("new succeeded");
 }
 
 #[test]

--- a/tests/env-migration.rs
+++ b/tests/env-migration.rs
@@ -18,7 +18,7 @@ use rkv::{
         Lmdb,
         SafeMode,
     },
-    migrator::Migrator,
+    Migrator,
     Rkv,
     StoreOptions,
     Value,
@@ -33,6 +33,152 @@ macro_rules! populate_store {
         store.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
         writer.commit().expect("committed");
     };
+}
+
+#[test]
+fn test_simple_migrator_lmdb_to_safe() {
+    let root = Builder::new().prefix("test_simple_migrator_lmdb_to_safe").tempdir().expect("tempdir");
+    fs::create_dir_all(root.path()).expect("dir created");
+
+    // Populate source environment and persist to disk.
+    {
+        let src_env = Rkv::new::<Lmdb>(root.path()).expect("new succeeded");
+        populate_store!(&src_env);
+        src_env.sync(true).expect("synced");
+    }
+    // Check if the files were written to disk.
+    {
+        let mut datamdb = root.path().to_path_buf();
+        let mut lockmdb = root.path().to_path_buf();
+        datamdb.push("data.mdb");
+        lockmdb.push("lock.mdb");
+        assert!(datamdb.exists());
+        assert!(lockmdb.exists());
+    }
+    // Verify that database was written to disk.
+    {
+        let src_env = Rkv::new::<Lmdb>(root.path()).expect("new succeeded");
+        let store = src_env.open_single("store", StoreOptions::default()).expect("opened");
+        let reader = src_env.read().expect("reader");
+        assert_eq!(store.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+        assert_eq!(store.get(&reader, "bar").expect("read"), Some(Value::Bool(true)));
+        assert_eq!(store.get(&reader, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+    }
+    // Easy migrate.
+    {
+        let dst_env = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        Migrator::auto_migrate_lmdb_to_safe_mode(root.path(), |builder| builder, &dst_env).expect("migrated");
+    }
+    // Verify that the database was indeed migrated.
+    {
+        let dst_env = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let store = dst_env.open_single("store", StoreOptions::default()).expect("opened");
+        let reader = dst_env.read().expect("reader");
+        assert_eq!(store.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+        assert_eq!(store.get(&reader, "bar").expect("read"), Some(Value::Bool(true)));
+        assert_eq!(store.get(&reader, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+    }
+    // Check if the old files were deleted from disk.
+    {
+        let mut datamdb = root.path().to_path_buf();
+        let mut lockmdb = root.path().to_path_buf();
+        datamdb.push("data.mdb");
+        lockmdb.push("lock.mdb");
+        assert!(!datamdb.exists());
+        assert!(!lockmdb.exists());
+    }
+}
+
+#[test]
+fn test_simple_migrator_safe_to_lmdb() {
+    let root = Builder::new().prefix("test_simple_migrator_safe_to_lmdb").tempdir().expect("tempdir");
+    fs::create_dir_all(root.path()).expect("dir created");
+
+    // Populate source environment and persist to disk.
+    {
+        let src_env = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        populate_store!(&src_env);
+        src_env.sync(true).expect("synced");
+    }
+    // Check if the files were written to disk.
+    {
+        let mut safebin = root.path().to_path_buf();
+        safebin.push("data.safe.bin");
+        assert!(safebin.exists());
+    }
+    // Verify that database was written to disk.
+    {
+        let src_env = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        let store = src_env.open_single("store", StoreOptions::default()).expect("opened");
+        let reader = src_env.read().expect("reader");
+        assert_eq!(store.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+        assert_eq!(store.get(&reader, "bar").expect("read"), Some(Value::Bool(true)));
+        assert_eq!(store.get(&reader, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+    }
+    // Easy migrate.
+    {
+        let dst_env = Rkv::new::<Lmdb>(root.path()).expect("new succeeded");
+        Migrator::auto_migrate_safe_mode_to_lmdb(root.path(), |builder| builder, &dst_env).expect("migrated");
+    }
+    // Verify that the database was indeed migrated.
+    {
+        let dst_env = Rkv::new::<Lmdb>(root.path()).expect("new succeeded");
+        let store = dst_env.open_single("store", StoreOptions::default()).expect("opened");
+        let reader = dst_env.read().expect("reader");
+        assert_eq!(store.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+        assert_eq!(store.get(&reader, "bar").expect("read"), Some(Value::Bool(true)));
+        assert_eq!(store.get(&reader, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+    }
+    // Check if the old files were deleted from disk.
+    {
+        let mut safebin = root.path().to_path_buf();
+        safebin.push("data.safe.bin");
+        assert!(!safebin.exists());
+    }
+}
+
+#[test]
+fn test_migrator_round_trip() {
+    let root = Builder::new().prefix("test_simple_migrator_lmdb_to_safe").tempdir().expect("tempdir");
+    fs::create_dir_all(root.path()).expect("dir created");
+
+    // Populate source environment and persist to disk.
+    {
+        let src_env = Rkv::new::<Lmdb>(root.path()).expect("new succeeded");
+        populate_store!(&src_env);
+        src_env.sync(true).expect("synced");
+    }
+    // Easy migrate.
+    {
+        let dst_env = Rkv::new::<SafeMode>(root.path()).expect("new succeeded");
+        Migrator::auto_migrate_lmdb_to_safe_mode(root.path(), |builder| builder, &dst_env).expect("migrated");
+    }
+    // Easy migrate back.
+    {
+        let dst_env = Rkv::new::<Lmdb>(root.path()).expect("new succeeded");
+        Migrator::auto_migrate_safe_mode_to_lmdb(root.path(), |builder| builder, &dst_env).expect("migrated");
+    }
+    // Verify that the database was indeed migrated twice.
+    {
+        let dst_env = Rkv::new::<Lmdb>(root.path()).expect("new succeeded");
+        let store = dst_env.open_single("store", StoreOptions::default()).expect("opened");
+        let reader = dst_env.read().expect("reader");
+        assert_eq!(store.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+        assert_eq!(store.get(&reader, "bar").expect("read"), Some(Value::Bool(true)));
+        assert_eq!(store.get(&reader, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+    }
+    // Check if the right files are finally present on disk.
+    {
+        let mut datamdb = root.path().to_path_buf();
+        let mut lockmdb = root.path().to_path_buf();
+        let mut safebin = root.path().to_path_buf();
+        datamdb.push("data.mdb");
+        lockmdb.push("lock.mdb");
+        safebin.push("data.safe.bin");
+        assert!(datamdb.exists());
+        assert!(lockmdb.exists());
+        assert!(!safebin.exists());
+    }
 }
 
 #[test]

--- a/tests/env-safe.rs
+++ b/tests/env-safe.rs
@@ -66,7 +66,7 @@ fn test_open_fails_safe() {
 
     let pb = nope.to_path_buf();
     match Rkv::new::<SafeMode>(nope.as_path()).err() {
-        Some(StoreError::DirectoryDoesNotExistError(p)) => {
+        Some(StoreError::UnsuitableEnvironmentPath(p)) => {
             assert_eq!(pb, p);
         },
         _ => panic!("expected error"),
@@ -112,7 +112,7 @@ fn test_open_from_builder_with_dir_safe_1() {
 }
 
 #[test]
-#[should_panic(expected = "rkv: DirectoryDoesNotExistError(\"bogus\")")]
+#[should_panic(expected = "rkv: UnsuitableEnvironmentPath(\"bogus\")")]
 fn test_open_from_builder_with_dir_safe_2() {
     let root = Path::new("bogus");
     println!("Root path: {:?}", root);


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

This makes it so that users don't need to manually open an old environment to migrate. Really they just want open their environment normally, and optionally populate it with with whatever was there to begin with.

This PR makes migration a one liner.