### PR TITLE
Add a way to discard corrupted databases on load

### DIFF
--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -91,7 +91,9 @@ pub trait BackendEnvironmentBuilder<'b>: Debug + Eq + PartialEq + Copy + Clone {
 
     fn set_map_size(&mut self, size: usize) -> &mut Self;
 
-    fn set_make_dir_if_needed(&mut self, make_dir: bool) -> &mut Self;
+    fn set_make_dir_if_needed(&mut self, make_dir_if_needed: bool) -> &mut Self;
+
+    fn set_discard_if_corrupted(&mut self, discard_if_corrupted: bool) -> &mut Self;
 
     fn open(&self, path: &Path) -> Result<Self::Environment, Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ pub use readwrite::{
 pub use store::{
     keys::EncodableKey,
     single::SingleStore,
+    CloseOptions,
     Options as StoreOptions,
 };
 pub use value::{

--- a/src/store.rs
+++ b/src/store.rs
@@ -39,3 +39,16 @@ where
         }
     }
 }
+
+#[derive(Default, Debug, Copy, Clone)]
+pub struct CloseOptions {
+    pub delete: bool,
+}
+
+impl CloseOptions {
+    pub fn delete_files_on_disk() -> CloseOptions {
+        CloseOptions {
+            delete: true,
+        }
+    }
+}

--- a/tests/manager.rs
+++ b/tests/manager.rs
@@ -17,12 +17,16 @@ use tempfile::Builder;
 
 use rkv::{
     backend::{
+        BackendEnvironmentBuilder,
         Lmdb,
         LmdbEnvironment,
         SafeMode,
         SafeModeEnvironment,
     },
+    CloseOptions,
     Rkv,
+    StoreOptions,
+    Value,
 };
 
 /// Test that a manager can be created with simple type inference.
@@ -133,4 +137,121 @@ fn test_same_with_capacity_safe() {
     let created_arc = manager.get_or_create_with_capacity(p, 10, Rkv::with_capacity::<SafeMode>).expect("created");
     let fetched_arc = manager.get(p).expect("success").expect("existed");
     assert!(Arc::ptr_eq(&created_arc, &fetched_arc));
+}
+
+/// Some storage drivers are able to discard when the database is corrupted at runtime.
+/// Test how these managers can discard corrupted databases and re-open.
+#[test]
+fn test_safe_mode_corrupt_while_open_1() {
+    type Manager = rkv::Manager<SafeModeEnvironment>;
+
+    let root = Builder::new().prefix("test_safe_mode_corrupt_while_open_1").tempdir().expect("tempdir");
+    fs::create_dir_all(root.path()).expect("dir created");
+
+    // Create environment.
+    let mut manager = Manager::singleton().write().unwrap();
+    let shared_env = manager.get_or_create(root.path(), Rkv::new::<SafeMode>).expect("created");
+    let env = shared_env.read().unwrap();
+
+    // Write some data.
+    let store = env.open_single("store", StoreOptions::create()).expect("opened");
+    let mut writer = env.write().expect("writer");
+    store.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+    store.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+    store.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+    writer.commit().expect("committed");
+    env.sync(true).expect("synced");
+
+    // Verify it was flushed to disk.
+    let mut safebin = root.path().to_path_buf();
+    safebin.push("data.safe.bin");
+    assert!(safebin.exists());
+
+    // Oops, corruption.
+    fs::write(&safebin, "bogus").expect("dbfile corrupted");
+
+    // Close everything.
+    drop(env);
+    drop(shared_env);
+    manager.try_close(root.path(), CloseOptions::default()).expect("closed without deleting");
+    assert!(manager.get(root.path()).expect("success").is_none());
+
+    // Recreating environment fails.
+    manager.get_or_create(root.path(), Rkv::new::<SafeMode>).expect_err("not created");
+    assert!(manager.get(root.path()).expect("success").is_none());
+
+    // But we can use a builder and pass `discard_if_corrupted` to deal with it.
+    let mut builder = Rkv::environment_builder::<SafeMode>();
+    builder.set_discard_if_corrupted(true);
+    manager.get_or_create_from_builder(root.path(), builder, Rkv::from_builder::<SafeMode>).expect("created");
+    assert!(manager.get(root.path()).expect("success").is_some());
+}
+
+/// Some storage drivers are able to recover when the database is corrupted at runtime.
+/// Test how these managers can recover corrupted databases while open.
+#[test]
+fn test_safe_mode_corrupt_while_open_2() {
+    type Manager = rkv::Manager<SafeModeEnvironment>;
+
+    let root = Builder::new().prefix("test_safe_mode_corrupt_while_open_2").tempdir().expect("tempdir");
+    fs::create_dir_all(root.path()).expect("dir created");
+
+    // Create environment.
+    let mut manager = Manager::singleton().write().unwrap();
+    let shared_env = manager.get_or_create(root.path(), Rkv::new::<SafeMode>).expect("created");
+    let env = shared_env.read().unwrap();
+
+    // Write some data.
+    let store = env.open_single("store", StoreOptions::create()).expect("opened");
+    let mut writer = env.write().expect("writer");
+    store.put(&mut writer, "foo", &Value::I64(1234)).expect("wrote");
+    store.put(&mut writer, "bar", &Value::Bool(true)).expect("wrote");
+    store.put(&mut writer, "baz", &Value::Str("héllo, yöu")).expect("wrote");
+    writer.commit().expect("committed");
+    env.sync(true).expect("synced");
+
+    // Verify it was flushed to disk.
+    let mut safebin = root.path().to_path_buf();
+    safebin.push("data.safe.bin");
+    assert!(safebin.exists());
+
+    // Oops, corruption.
+    fs::write(&safebin, "bogus").expect("dbfile corrupted");
+
+    // Reading still works. Magic.
+    let store = env.open_single("store", StoreOptions::default()).expect("opened");
+    let reader = env.read().expect("reader");
+    assert_eq!(store.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+    assert_eq!(store.get(&reader, "bar").expect("read"), Some(Value::Bool(true)));
+    assert_eq!(store.get(&reader, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+    reader.abort();
+
+    // Writing still works, dbfile will be un-corrupted.
+    let store = env.open_single("store", StoreOptions::default()).expect("opened");
+    let mut writer = env.write().expect("writer");
+    store.put(&mut writer, "foo2", &Value::I64(5678)).expect("wrote");
+    store.put(&mut writer, "bar2", &Value::Bool(false)).expect("wrote");
+    store.put(&mut writer, "baz2", &Value::Str("byé, yöu")).expect("wrote");
+    writer.commit().expect("committed");
+    env.sync(true).expect("synced");
+
+    // Close everything.
+    drop(env);
+    drop(shared_env);
+    manager.try_close(root.path(), CloseOptions::default()).expect("closed without deleting");
+    assert!(manager.get(root.path()).expect("success").is_none());
+
+    // Recreate environment.
+    let shared_env = manager.get_or_create(root.path(), Rkv::new::<SafeMode>).expect("created");
+    let env = shared_env.read().unwrap();
+
+    // Verify that the dbfile is not corrupted.
+    let store = env.open_single("store", StoreOptions::default()).expect("opened");
+    let reader = env.read().expect("reader");
+    assert_eq!(store.get(&reader, "foo").expect("read"), Some(Value::I64(1234)));
+    assert_eq!(store.get(&reader, "bar").expect("read"), Some(Value::Bool(true)));
+    assert_eq!(store.get(&reader, "baz").expect("read"), Some(Value::Str("héllo, yöu")));
+    assert_eq!(store.get(&reader, "foo2").expect("read"), Some(Value::I64(5678)));
+    assert_eq!(store.get(&reader, "bar2").expect("read"), Some(Value::Bool(false)));
+    assert_eq!(store.get(&reader, "baz2").expect("read"), Some(Value::Str("byé, yöu")));
 }


### PR DESCRIPTION
Right now, if database files are corrupted, opening an environment at that path will fail with `FileInvalid` (every time with SafeMode, and only _sometimes_ with LMDB unless corruption is extreme in which case we just crash).

The only way for users to deal this right now is to manually delete the files before attempting to reopen –– which is also incorrect if there's lingering environments. This is also very inelegant when dealing with multiple possible backends, where users might not know exactly which files to delete.

I've recently added `try_close_and_delete` to Managers, and `close_and_delete` to Environments, which delete the files on close. This is only useful though if you've already successfully opened an environment at least once with the former, or already have direct ownership of an environment with the latter, and can therefore guarantee that there's no other environments open in other threads for example.

This PR makes the following changes:
* Adds a `set_discard_if_corrupted` method to environment builders to actually deal with this problem.
* Turns Environments `close_and_delete(self)` into `close(self, options: CloseOptions)`, that makes deleting files optional. This is useful for testing, but I can imagine it being useful in other situations as well.
* Adds a specific class of errors called `CloseError` which only happen when closing, to distinguish them from `StoreError`s. This helps isolating errors coming from a particular part of a migration process for example, where IOError could mean "failed to open", as well as "failed to delete while closing".