### PR TITLE
Update dependencies to minimal supported versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,14 @@ with-fuzzer-no-link = ["lmdb-rkv/with-fuzzer-no-link"]
 [dependencies]
 arrayref = "0.3"
 bincode = "1.0"
-bitflags = "1"
+bitflags = "1.1"
 byteorder = "1"
 id-arena = "2.2"
-lazy_static = "1.0"
+lazy_static = "1.1"
 lmdb-rkv = "0.14"
-log = "0.4"
+log = "0.4.4"
 ordered-float = "1.0.1"
-paste = "0.1"
+paste = "0.1.11"
 serde = {version = "1.0", features = ["derive", "rc"]}
 serde_derive = "1.0"
 url = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ id-arena = "2.2"
 lazy_static = "1.0"
 lmdb-rkv = "0.14"
 log = "0.4"
-ordered-float = "1.0"
+ordered-float = "1.0.1"
 paste = "0.1"
 serde = {version = "1.0", features = ["derive", "rc"]}
 serde_derive = "1.0"


### PR DESCRIPTION
I am trying to build Glean using minimal versions (`cargo +nightly update -Z minimal-versions`) and this is another dependency that breaks.

ordered-float dropped the `unreachable` dependency in 1.0.1, which makes it work again.