### PR TITLE
Replace failure with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ repository = "https://github.com/mozilla/rkv"
 version = "0.16.0"
 
 [features]
-backtrace = ["failure/backtrace", "failure/std"]
 db-dup-sort = []
 db-int-key = []
 default = ["db-dup-sort", "db-int-key"]
@@ -41,15 +40,9 @@ ordered-float = "1.0"
 paste = "0.1"
 serde = {version = "1.0", features = ["derive", "rc"]}
 serde_derive = "1.0"
+thiserror = "1.0"
 url = "2.0"
 uuid = "0.8"
-
-# Get rid of failure's dependency on backtrace. Eventually
-# backtrace will move into Rust core, but we don't need it here.
-[dependencies.failure]
-default_features = false
-features = ["derive"]
-version = "0.1"
 
 [dev-dependencies]
 byteorder = "1"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ There are several features that you can opt-in and out of when using rkv:
 
 By default, `db-dup-sort` and `db-int-key` features offer high level database APIs which allow multiple values per key, and optimizations around integer-based keys respectively. Opt out of these default features when specifying the rkv dependency in your Cargo.toml file to disable them; doing so avoids a certain amount of overhead required to support them.
 
-If you specify the `backtrace` feature, backtraces will be enabled in "failure" errors. This feature is disabled by default.
-
 To aid fuzzing efforts, `with-asan`, `with-fuzzer`, and `with-fuzzer-no-link` configure the build scripts responsible with compiling the underlying backing engines (e.g. LMDB) to build with these LLMV features enabled. Please refer to the official LLVM/Clang documentation on them for more informatiuon. These features are also disabled by default.
 
 ## Test

--- a/src/backend/impl_lmdb/arch_migrator_error.rs
+++ b/src/backend/impl_lmdb/arch_migrator_error.rs
@@ -14,78 +14,60 @@ use std::{
     str,
 };
 
-use failure::Fail;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum MigrateError {
-    #[fail(display = "database not found: {:?}", _0)]
+    #[error("database not found: {0:?}")]
     DatabaseNotFound(String),
 
-    #[fail(display = "{}", _0)]
+    #[error("{0}")]
     FromString(String),
 
-    #[fail(display = "couldn't determine bit depth")]
+    #[error("couldn't determine bit depth")]
     IndeterminateBitDepth,
 
-    #[fail(display = "I/O error: {:?}", _0)]
-    IoError(io::Error),
+    #[error("I/O error: {0:?}")]
+    IoError(#[from] io::Error),
 
-    #[fail(display = "invalid DatabaseFlags bits")]
+    #[error("invalid DatabaseFlags bits")]
     InvalidDatabaseBits,
 
-    #[fail(display = "invalid data version")]
+    #[error("invalid data version")]
     InvalidDataVersion,
 
-    #[fail(display = "invalid magic number")]
+    #[error("invalid magic number")]
     InvalidMagicNum,
 
-    #[fail(display = "invalid NodeFlags bits")]
+    #[error("invalid NodeFlags bits")]
     InvalidNodeBits,
 
-    #[fail(display = "invalid PageFlags bits")]
+    #[error("invalid PageFlags bits")]
     InvalidPageBits,
 
-    #[fail(display = "invalid page number")]
+    #[error("invalid page number")]
     InvalidPageNum,
 
-    #[fail(display = "lmdb backend error: {}", _0)]
-    LmdbError(lmdb::Error),
+    #[error("lmdb backend error: {0}")]
+    LmdbError(#[from] lmdb::Error),
 
-    #[fail(display = "string conversion error")]
+    #[error("string conversion error")]
     StringConversionError,
 
-    #[fail(display = "TryFromInt error: {:?}", _0)]
-    TryFromIntError(num::TryFromIntError),
+    #[error("TryFromInt error: {0:?}")]
+    TryFromIntError(#[from] num::TryFromIntError),
 
-    #[fail(display = "unexpected Page variant")]
+    #[error("unexpected Page variant")]
     UnexpectedPageVariant,
 
-    #[fail(display = "unexpected PageHeader variant")]
+    #[error("unexpected PageHeader variant")]
     UnexpectedPageHeaderVariant,
 
-    #[fail(display = "unsupported PageHeader variant")]
+    #[error("unsupported PageHeader variant")]
     UnsupportedPageHeaderVariant,
 
-    #[fail(display = "UTF8 error: {:?}", _0)]
-    Utf8Error(str::Utf8Error),
-}
-
-impl From<io::Error> for MigrateError {
-    fn from(e: io::Error) -> MigrateError {
-        MigrateError::IoError(e)
-    }
-}
-
-impl From<str::Utf8Error> for MigrateError {
-    fn from(e: str::Utf8Error) -> MigrateError {
-        MigrateError::Utf8Error(e)
-    }
-}
-
-impl From<num::TryFromIntError> for MigrateError {
-    fn from(e: num::TryFromIntError) -> MigrateError {
-        MigrateError::TryFromIntError(e)
-    }
+    #[error("UTF8 error: {0:?}")]
+    Utf8Error(#[from] str::Utf8Error),
 }
 
 impl From<&str> for MigrateError {
@@ -97,11 +79,5 @@ impl From<&str> for MigrateError {
 impl From<String> for MigrateError {
     fn from(e: String) -> MigrateError {
         MigrateError::FromString(e)
-    }
-}
-
-impl From<lmdb::Error> for MigrateError {
-    fn from(e: lmdb::Error) -> MigrateError {
-        MigrateError::LmdbError(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 //! It aims to achieve the following:
 //!
 //! - Avoid sharp edges (e.g., obscure error codes for common situations).
-//! - Report errors via [failure](https://docs.rs/failure/).
 //! - Correctly restrict access to one handle per process via a
 //!   [Manager](struct.Manager.html).
 //! - Use Rust's type system to make single-typed key stores safe and ergonomic.


### PR DESCRIPTION
[`failure`](https://github.com/rust-lang-nursery/failure) has been deprecated in favor of `thiserror`. This PR replaces it.