### PR TITLE
Upgrade to latest ordered-float

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ id-arena = "2.2"
 lazy_static = "1.1"
 lmdb-rkv = "0.14"
 log = "0.4.4"
-ordered-float = "1.0.1"
+ordered-float = "3.0.0"
 paste = "1.0.6"
 serde = {version = "1.0", features = ["derive", "rc"]}
 serde_derive = "1.0"


### PR DESCRIPTION
Also contains the fixes for https://github.com/advisories/GHSA-566x-hhrf-qf8m