### PR TITLE
Allow bitflags 1.2+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ with-fuzzer-no-link = ["lmdb", "lmdb-rkv/with-fuzzer-no-link"]
 [dependencies]
 arrayref = "0.3"
 bincode = "1.0"
-bitflags = "~1.2"
+bitflags = "1.2"
 byteorder = "1"
 id-arena = "2.2"
 lazy_static = "1.1"


### PR DESCRIPTION
Not sure why this was restricted, but unless we losen this dependency range we cannot get it into m-c.