### PR TITLE
Write database to temp file first, then atomically move it

### DIFF
--- a/src/backend/impl_safe/environment.rs
+++ b/src/backend/impl_safe/environment.rs
@@ -217,7 +217,13 @@ impl EnvironmentImpl {
         if fs::metadata(&path)?.is_dir() {
             path.to_mut().push(DEFAULT_DB_FILENAME);
         };
-        fs::write(&path, self.serialize()?)?;
+
+        // Write to a temp file first.
+        let tmp_path = path.with_extension("tmp");
+        fs::write(&tmp_path, self.serialize()?)?;
+
+        // Atomically move that file to the database file.
+        fs::rename(tmp_path, path)?;
         Ok(())
     }
 


### PR DESCRIPTION
This ensures that _some_ data is still around in the case that the write gets interrupted early.
This currently can cause data loss with the whole database getting wiped.