### PR TITLE
Upgrade `bitflags` to from 1.2 to 2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ with-fuzzer-no-link = ["lmdb", "lmdb-rkv/with-fuzzer-no-link"]
 [dependencies]
 arrayref = "0.3"
 bincode = "1.0"
-bitflags = "1.2"
+bitflags = {version = "2.4.1", features = ["serde"]}
 byteorder = "1"
 id-arena = "2.2"
 lazy_static = "1.1"

--- a/src/backend/impl_lmdb/arch_migrator.rs
+++ b/src/backend/impl_lmdb/arch_migrator.rs
@@ -83,7 +83,7 @@ const MAGIC: [u8; 4] = [0xDE, 0xC0, 0xEF, 0xBE];
 pub type MigrateResult<T> = Result<T, MigrateError>;
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Default, PartialEq, Eq, Debug, Clone, Copy)]
     struct PageFlags: u16 {
         const BRANCH = 0x01;
         const LEAF = 0x02;
@@ -98,7 +98,7 @@ bitflags! {
 }
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Default, PartialEq, Eq, Debug, Clone, Copy)]
     struct NodeFlags: u16 {
         const BIGDATA = 0x01;
         const SUBDATA = 0x02;

--- a/src/backend/impl_safe/environment.rs
+++ b/src/backend/impl_safe/environment.rs
@@ -272,7 +272,8 @@ impl<'e> BackendEnvironment<'e> for EnvironmentImpl {
         // TOOD: don't reallocate `name`.
         let key = name.map(String::from);
         let mut dbs = self.dbs.write().map_err(|_| ErrorImpl::EnvPoisonError)?;
-        if dbs.name_map.keys().filter_map(|k| k.as_ref()).count() >= self.max_dbs && name.is_some() {
+        if dbs.name_map.keys().filter_map(|k| k.as_ref()).count() >= self.max_dbs && name.is_some()
+        {
             return Err(ErrorImpl::DbsFull);
         }
         let parts = EnvironmentDbsRefMut::from(dbs.deref_mut());

--- a/src/backend/impl_safe/flags.rs
+++ b/src/backend/impl_safe/flags.rs
@@ -17,7 +17,7 @@ use crate::backend::{
 };
 
 bitflags! {
-    #[derive(Default, Serialize, Deserialize)]
+    #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
     pub struct EnvironmentFlagsImpl: u32 {
         const NIL = 0b0000_0000;
     }
@@ -54,7 +54,7 @@ impl Into<EnvironmentFlagsImpl> for EnvironmentFlags {
 }
 
 bitflags! {
-    #[derive(Default, Serialize, Deserialize)]
+    #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
     pub struct DatabaseFlagsImpl: u32 {
         const NIL = 0b0000_0000;
         #[cfg(feature = "db-dup-sort")]
@@ -93,7 +93,7 @@ impl Into<DatabaseFlagsImpl> for DatabaseFlags {
 }
 
 bitflags! {
-    #[derive(Default, Serialize, Deserialize)]
+    #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
     pub struct WriteFlagsImpl: u32 {
         const NIL = 0b0000_0000;
     }


### PR DESCRIPTION
This should fix the Nightly failure in #235 (which is not a blocker).

Followed the migration guide of https://github.com/bitflags/bitflags/releases/tag/2.0.0. `PartialEq, Eq, Debug, Clone, Copy` is to match the BackendFlags requirement:

https://github.com/mozilla/rkv/blob/55a5a4dc94e84d77e25637dc68dc8222c72db403/src/backend/traits.rs#L25