### PR TITLE
Implement `MallocSizeOf` for Rkv internals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - run: cargo build --verbose
 
       - name: Test with all features
-        run: cargo test --all --verbose
+        run: cargo test --all --all-features --verbose
 
       - name: Test with no default features
         run: cargo test --lib --no-default-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ db-dup-sort = []
 db-int-key = []
 default = ["db-dup-sort", "db-int-key"]
 no-canonicalize-path = []
+malloc-size-of = ["dep:malloc_size_of", "dep:malloc_size_of_derive"]
 
 [dependencies]
 arrayref = "0.3"
@@ -38,6 +39,8 @@ serde_derive = "1.0"
 thiserror = "2.0"
 url = "2.0"
 uuid = "1.0"
+malloc_size_of_derive = { version = "0.1.3", optional = true }
+malloc_size_of = { version = "0.2.2", package = "wr_malloc_size_of", default-features = false, optional = true }
 
 [dev-dependencies]
 byteorder = "1"

--- a/src/backend/common.rs
+++ b/src/backend/common.rs
@@ -45,6 +45,7 @@ pub enum WriteFlags {
 
 /// Strategy to use when corrupted data is detected while opening a database.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "malloc-size-of", derive(malloc_size_of_derive::MallocSizeOf))]
 pub enum RecoveryStrategy {
     /// Bubble up the error on detecting a corrupted data file. The default.
     Error,

--- a/src/backend/impl_safe/database.rs
+++ b/src/backend/impl_safe/database.rs
@@ -17,9 +17,18 @@ use crate::backend::traits::BackendDatabase;
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub struct DatabaseImpl(pub(crate) Id<Database>);
 
+#[cfg(feature = "malloc-size-of")]
+impl malloc_size_of::MallocSizeOf for DatabaseImpl {
+    fn size_of(&self, _ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        // Id<T> does not allocate
+        0
+    }
+}
+
 impl BackendDatabase for DatabaseImpl {}
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "malloc-size-of", derive(malloc_size_of_derive::MallocSizeOf))]
 pub struct Database {
     snapshot: Snapshot,
 }

--- a/src/backend/impl_safe/flags.rs
+++ b/src/backend/impl_safe/flags.rs
@@ -23,6 +23,13 @@ bitflags! {
     }
 }
 
+#[cfg(feature = "malloc-size-of")]
+impl malloc_size_of::MallocSizeOf for EnvironmentFlagsImpl {
+    fn size_of(&self, _ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        0
+    }
+}
+
 impl BackendFlags for EnvironmentFlagsImpl {
     fn empty() -> EnvironmentFlagsImpl {
         EnvironmentFlagsImpl::empty()
@@ -61,6 +68,13 @@ bitflags! {
         const DUP_SORT = 0b0000_0001;
         #[cfg(feature = "db-int-key")]
         const INTEGER_KEY = 0b0000_0010;
+    }
+}
+
+#[cfg(feature = "malloc-size-of")]
+impl malloc_size_of::MallocSizeOf for DatabaseFlagsImpl {
+    fn size_of(&self, _ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        0
     }
 }
 

--- a/src/backend/impl_safe/snapshot.rs
+++ b/src/backend/impl_safe/snapshot.rs
@@ -29,6 +29,21 @@ pub struct Snapshot {
     map: Arc<BTreeMap<Key, BTreeSet<Value>>>,
 }
 
+#[cfg(feature = "malloc-size-of")]
+impl malloc_size_of::MallocSizeOf for Snapshot {
+    fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        let mut n = 0;
+        n += self.flags.size_of(ops);
+
+        // All other clones of the `Snapshot` map are transient in a transaction
+        // and thus not reachable from the `Database` object,
+        // so we're safe counting them here.
+        n += (*self.map).size_of(ops);
+
+        n
+    }
+}
+
 impl Snapshot {
     pub(crate) fn new(flags: Option<DatabaseFlagsImpl>) -> Snapshot {
         Snapshot {

--- a/src/env.rs
+++ b/src/env.rs
@@ -41,6 +41,7 @@ pub static DEFAULT_MAX_DBS: c_uint = 5;
 
 /// Wrapper around an `Environment` (e.g. a `SafeMode` environment).
 #[derive(Debug)]
+#[cfg_attr(feature = "malloc-size-of", derive(malloc_size_of_derive::MallocSizeOf))]
 pub struct Rkv<E> {
     _path: PathBuf,
     env: E,

--- a/src/store/single.rs
+++ b/src/store/single.rs
@@ -21,6 +21,7 @@ use crate::{
 type EmptyResult = Result<(), StoreError>;
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "malloc-size-of", derive(malloc_size_of_derive::MallocSizeOf))]
 pub struct SingleStore<D> {
     db: D,
 }


### PR DESCRIPTION
This will allow to measure the allocated memory used by the database. It's only implemented for `safe-mode`.

---

Putting this up, so I can point to it and hopefully soon move forward with it.